### PR TITLE
feat(web): implement Engine Core skeleton and TS SDK entrypoint (#2)

### DIFF
--- a/packages/inderun-web/README.md
+++ b/packages/inderun-web/README.md
@@ -1,0 +1,19 @@
+# @independo/inderun-web
+
+This is the JS/TS Engine Core and Web SDK package for the IndeRun framework.
+
+It implements:
+- `ProviderRegistry` for registering execution adapters.
+- `Router` for deterministic routing based on policy and host capability snapshots.
+- Standard error taxonomy (`IndeRunException`) and error mapping.
+- Core orchestrator flow with timing and telemetry measurements.
+
+## Commands
+
+```sh
+# Build the package
+pnpm --filter @independo/inderun-web build
+
+# Run unit tests
+pnpm --filter @independo/inderun-web test
+```

--- a/packages/inderun-web/package.json
+++ b/packages/inderun-web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@independo/inderun-web",
+  "version": "0.1.0",
+  "description": "TypeScript/Web SDK for IndeRun.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@independo/inderun-contracts": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/inderun-web/src/engine.test.ts
+++ b/packages/inderun-web/src/engine.test.ts
@@ -1,0 +1,369 @@
+import type { TaskRequest, TaskResult } from "@independo/inderun-contracts";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  IndeRun,
+  ProviderRegistry,
+  IndeRunException,
+  type HostServices,
+  type ProviderAdapter
+} from "./index.js";
+
+function createMockLocalProvider(id: string, available = true): ProviderAdapter {
+  return {
+    describe() {
+      return {
+        id,
+        type: "local",
+        transport: "system_service",
+        supports: {
+          run: true,
+          streaming: false,
+          realtime: false,
+          tools: false,
+          reasoningEvents: false,
+          structuredOutput: false,
+          multimodal: false
+        },
+        cancel: "none",
+        tasks: ["text_to_text"]
+      };
+    },
+    async capabilities() {
+      return { available };
+    },
+    async run(req: TaskRequest): Promise<TaskResult> {
+      return {
+        schemaVersion: "1.0",
+        runId: req.requestId || "run-123",
+        output: {
+          type: "text",
+          text: `Mock local response: ${req.prompt}`
+        },
+        finishReason: "stop",
+        telemetry: {
+          providerUsed: id,
+          totalMs: 0
+        }
+      };
+    }
+  };
+}
+
+function createMockCloudProvider(id: string, available = true): ProviderAdapter {
+  return {
+    describe() {
+      return {
+        id,
+        type: "cloud",
+        transport: "http",
+        supports: {
+          run: true,
+          streaming: false,
+          realtime: false,
+          tools: false,
+          reasoningEvents: false,
+          structuredOutput: false,
+          multimodal: false
+        },
+        cancel: "none",
+        tasks: ["text_to_text"]
+      };
+    },
+    async capabilities() {
+      return { available };
+    },
+    async run(req: TaskRequest): Promise<TaskResult> {
+      return {
+        schemaVersion: "1.0",
+        runId: req.requestId || "run-123",
+        output: {
+          type: "text",
+          text: `Mock cloud response: ${req.prompt}`
+        },
+        finishReason: "stop",
+        telemetry: {
+          providerUsed: id,
+          totalMs: 0
+        }
+      };
+    }
+  };
+}
+
+function createMockHostServices(online = true): HostServices {
+  let timeVal = 1000;
+  return {
+    connectivity: {
+      async isOnline() {
+        return online;
+      }
+    },
+    clock: {
+      now() {
+        // Monotonically increments on every call for predictable time duration testing
+        timeVal += 50;
+        return timeVal;
+      }
+    }
+  };
+}
+
+describe("IndeRun Engine Core Skeleton Tests", () => {
+  let registry: ProviderRegistry;
+
+  beforeEach(() => {
+    registry = new ProviderRegistry();
+  });
+
+  describe("ProviderRegistry", () => {
+    it("throws an error when registering a provider with a duplicate ID", () => {
+      const p1 = createMockLocalProvider("mock-local-1");
+      const p2 = createMockLocalProvider("mock-local-1");
+      registry.register(p1);
+      expect(() => registry.register(p2)).toThrowError(
+        /Provider with ID "mock-local-1" is already registered/
+      );
+    });
+  });
+
+  describe("Request Validation", () => {
+    it("fails early with Internal error if request payload is invalid", async () => {
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      // Prompt is missing and task format is invalid
+      const invalidRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "invalid_task" },
+        policy: { execution: "cloud" }
+      } as unknown as TaskRequest;
+
+      await expect(engine.run(invalidRequest)).rejects.toThrowError(
+        /Validation failed for TaskRequest/
+      );
+
+      try {
+        await engine.run(invalidRequest);
+      } catch (err) {
+        expect(err).toBeInstanceOf(IndeRunException);
+        const exception = err as IndeRunException;
+        expect(exception.errorClass).toBe("Internal");
+        expect(exception.details?.validationIssues).toBeDefined();
+        // Timing should be populated
+        expect(exception.details?.totalMs).toBe(50);
+      }
+    });
+
+    it("fails with Internal error if secrets are present in the request", async () => {
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const invalidRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "Hello",
+        policy: { execution: "cloud" },
+        apiKey: "sk-should-not-be-here" // forbidden key
+      } as unknown as TaskRequest;
+
+      await expect(engine.run(invalidRequest)).rejects.toThrowError(
+        /Inline secrets are not allowed/
+      );
+    });
+  });
+
+  describe("Routing execution = on_device", () => {
+    it("routes successfully to a local provider when execution is on_device and local provider is available", async () => {
+      const provider = createMockLocalProvider("mock-local-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "on_device" }
+      };
+
+      const result = await engine.run(req);
+      expect(result.output.text).toBe("Mock local response: test prompt");
+      expect(result.telemetry.providerUsed).toBe("mock-local-1");
+      // Timings: the mock clock is read only at start and end, so total elapsed time is one 50ms increment.
+      expect(result.telemetry.totalMs).toBe(50);
+    });
+
+    it("ensures the result runId matches the engine's runId", async () => {
+      const provider = createMockLocalProvider("mock-local-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "on_device" },
+        requestId: "orchestrator-run-999"
+      };
+
+      const result = await engine.run(req);
+      expect(result.runId).toBe("orchestrator-run-999");
+    });
+
+    it("throws CapabilityMismatch if on_device execution selected but no local providers are registered", async () => {
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "on_device" }
+      };
+
+      await expect(engine.run(req)).rejects.toThrowError(
+        /no on-device provider found/
+      );
+
+      try {
+        await engine.run(req);
+      } catch (err) {
+        expect(err).toBeInstanceOf(IndeRunException);
+        const exception = err as IndeRunException;
+        expect(exception.errorClass).toBe("CapabilityMismatch");
+        expect(exception.details?.totalMs).toBeDefined();
+      }
+    });
+
+    it("throws CapabilityMismatch if on_device selected but registered local provider is unavailable", async () => {
+      const provider = createMockLocalProvider("mock-local-unavailable", false);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "on_device" }
+      };
+
+      await expect(engine.run(req)).rejects.toThrowError(
+        /on-device provider is currently unavailable/
+      );
+
+      try {
+        await engine.run(req);
+      } catch (err) {
+        expect(err).toBeInstanceOf(IndeRunException);
+        const exception = err as IndeRunException;
+        expect(exception.errorClass).toBe("CapabilityMismatch");
+      }
+    });
+  });
+
+  describe("Routing execution = cloud", () => {
+    it("routes successfully to a cloud provider when execution is cloud, network is online and provider available", async () => {
+      const provider = createMockCloudProvider("mock-cloud-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "cloud" }
+      };
+
+      const result = await engine.run(req);
+      expect(result.output.text).toBe("Mock cloud response: test prompt");
+      expect(result.telemetry.providerUsed).toBe("mock-cloud-1");
+      expect(result.telemetry.totalMs).toBe(50);
+    });
+
+    it("throws Offline if cloud execution is selected but the device is offline", async () => {
+      const provider = createMockCloudProvider("mock-cloud-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(false); // offline
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "cloud" }
+      };
+
+      await expect(engine.run(req)).rejects.toThrowError(
+        /no network connection is available/
+      );
+
+      try {
+        await engine.run(req);
+      } catch (err) {
+        expect(err).toBeInstanceOf(IndeRunException);
+        const exception = err as IndeRunException;
+        expect(exception.errorClass).toBe("Offline");
+        expect(exception.details?.totalMs).toBeDefined();
+      }
+    });
+
+    it("throws Unavailable if cloud selected, online, but no cloud providers are registered", async () => {
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "cloud" }
+      };
+
+      await expect(engine.run(req)).rejects.toThrowError(
+        /no cloud provider found/
+      );
+
+      try {
+        await engine.run(req);
+      } catch (err) {
+        expect(err).toBeInstanceOf(IndeRunException);
+        const exception = err as IndeRunException;
+        expect(exception.errorClass).toBe("Unavailable");
+      }
+    });
+
+    it("throws Unavailable if cloud selected, online, but cloud provider is unavailable", async () => {
+      const provider = createMockCloudProvider("mock-cloud-unavailable", false);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const engine = new IndeRun(registry, host);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        policy: { execution: "cloud" }
+      };
+
+      await expect(engine.run(req)).rejects.toThrowError(
+        /no cloud provider is currently available/
+      );
+
+      try {
+        await engine.run(req);
+      } catch (err) {
+        expect(err).toBeInstanceOf(IndeRunException);
+        const exception = err as IndeRunException;
+        expect(exception.errorClass).toBe("Unavailable");
+      }
+    });
+  });
+});

--- a/packages/inderun-web/src/engine.ts
+++ b/packages/inderun-web/src/engine.ts
@@ -1,0 +1,111 @@
+import {
+  getTaskRequestValidationIssues,
+  type TaskRequest,
+  type TaskResult
+} from "@independo/inderun-contracts";
+import type { HostServices } from "./host.js";
+import { ProviderRegistry } from "./registry.js";
+import { Router } from "./router.js";
+import { createInternal, toIndeRunException } from "./errors.js";
+
+/**
+ * Main orchestrator SDK entrypoint class.
+ * Validates tasks, executes routing rules based on execution policies and connectivity,
+ * triggers provider adapters, and logs timing telemetry.
+ */
+export class IndeRun {
+  private router: Router;
+
+  /**
+   * Initializes the IndeRun instance.
+   * @param registry - Registry filled with active providers.
+   * @param hostServices - Services wrapping OS interfaces and indicators.
+   */
+  constructor(
+    private registry: ProviderRegistry,
+    private hostServices: HostServices
+  ) {
+    this.router = new Router(this.registry);
+  }
+
+  /**
+   * Orchestrates the execution of a TaskRequest.
+   * Performs JSON Schema validation, selects a provider via routing rules,
+   * measures total execution time, and attaches telemetry metadata to the outcome.
+   * @param request - The canonical task request containing prompts, tasks, and policies.
+   * @returns Canonical task output containing output details and telemetry metadata.
+   * @throws {IndeRunException} Standardized error indicating validation, connection, or provider failures.
+   */
+  async run(request: TaskRequest): Promise<TaskResult> {
+    const startTime = this.hostServices.clock
+      ? this.hostServices.clock.now()
+      : Date.now();
+
+    const runId =
+      request.requestId ||
+      `run_${Math.random().toString(36).substring(2, 11)}`;
+
+    try {
+      // 1. Validate request payload using schema contracts
+      const validationIssues = getTaskRequestValidationIssues(request);
+      if (validationIssues.length > 0) {
+        const message = `Validation failed for TaskRequest: ${validationIssues
+          .map((i) => `${i.path} - ${i.message}`)
+          .join("; ")}`;
+        throw createInternal(message, {
+          runId,
+          details: { validationIssues }
+        });
+      }
+
+      // 2. Select the route based on policy and host capabilities
+      const routeSelection = await this.router.selectRoute(
+        request,
+        this.hostServices
+      );
+      const provider = routeSelection.provider;
+
+      // 3. Execute the run task on the selected provider
+      let result: TaskResult;
+      try {
+        result = await provider.run(request, { runId });
+      } catch (err) {
+        const exc = toIndeRunException(err, {
+          providerId: provider.describe().id,
+          runId
+        });
+        throw exc;
+      }
+
+      // 4. Record timings and finalize telemetry
+      const endTime = this.hostServices.clock
+        ? this.hostServices.clock.now()
+        : Date.now();
+      const totalMs = endTime - startTime;
+
+      // Ensure the returned runId matches the engine's orchestrated runId
+      result.runId = runId;
+
+      // Ensure standard telemetry fields are present
+      result.telemetry = {
+        ...result.telemetry,
+        providerUsed: provider.describe().id,
+        totalMs
+      };
+
+      return result;
+    } catch (err) {
+      const endTime = this.hostServices.clock
+        ? this.hostServices.clock.now()
+        : Date.now();
+      const totalMs = endTime - startTime;
+
+      const exception = toIndeRunException(err, {
+        runId,
+        details: { totalMs }
+      });
+
+      throw exception;
+    }
+  }
+}

--- a/packages/inderun-web/src/errors.ts
+++ b/packages/inderun-web/src/errors.ts
@@ -1,0 +1,220 @@
+import type { IndeRunError, IndeRunErrorClass } from "@independo/inderun-contracts";
+
+/**
+ * Parameter structure required to initialize an IndeRunException.
+ */
+export interface IndeRunExceptionParams {
+  /**
+   * The standardized error class (e.g. 'CapabilityMismatch', 'Offline').
+   */
+  errorClass: IndeRunErrorClass;
+  /**
+   * Explanatory human-readable message.
+   */
+  message: string;
+  /**
+   * The unique run ID where this exception occurred.
+   */
+  runId?: string;
+  /**
+   * The provider ID that triggered the exception, if execution reached a provider.
+   */
+  providerId?: string;
+  /**
+   * Whether the client should retry this request.
+   */
+  retryable?: boolean;
+  /**
+   * Backoff time suggestion in milliseconds before retrying.
+   */
+  retryAfterMs?: number;
+  /**
+   * Rich contextual metadata regarding the error.
+   */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Standardized framework exception thrown when route selection or provider execution fails.
+ * Extends the native JavaScript Error class and exposes normalized error schema fields.
+ */
+export class IndeRunException extends Error {
+  /** The schema version matching the API contracts. */
+  readonly schemaVersion = "1.0";
+  /** The categorized class of error. */
+  readonly errorClass: IndeRunErrorClass;
+  /** The unique execution run ID. */
+  readonly runId?: string;
+  /** The provider ID responsible for the error. */
+  readonly providerId?: string;
+  /** Whether the error is transient and retryable. */
+  readonly retryable?: boolean;
+  /** Suggested cooling-down time in milliseconds before retry. */
+  readonly retryAfterMs?: number;
+  /** Custom details and metadata context. */
+  readonly details?: Record<string, unknown>;
+
+  constructor(params: IndeRunExceptionParams) {
+    super(params.message);
+    this.name = "IndeRunException";
+    this.errorClass = params.errorClass;
+    if (params.runId !== undefined) this.runId = params.runId;
+    if (params.providerId !== undefined) this.providerId = params.providerId;
+    if (params.retryable !== undefined) this.retryable = params.retryable;
+    if (params.retryAfterMs !== undefined) this.retryAfterMs = params.retryAfterMs;
+    if (params.details !== undefined) this.details = params.details;
+
+    Object.setPrototypeOf(this, IndeRunException.prototype);
+  }
+
+  /**
+   * Converts the exception into a JSON-compatible contract-compliant IndeRunError.
+   */
+  toContractError(): IndeRunError {
+    const err: IndeRunError = {
+      schemaVersion: this.schemaVersion,
+      errorClass: this.errorClass,
+      message: this.message,
+    };
+    if (this.runId !== undefined) err.runId = this.runId;
+    if (this.providerId !== undefined) err.providerId = this.providerId;
+    if (this.retryable !== undefined) err.retryable = this.retryable;
+    if (this.retryAfterMs !== undefined) err.retryAfterMs = this.retryAfterMs;
+    if (this.details !== undefined) err.details = this.details;
+    return err;
+  }
+}
+
+/**
+ * Factory helper for CapabilityMismatch error class.
+ */
+export function createCapabilityMismatch(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "CapabilityMismatch", message, ...extra });
+}
+
+/**
+ * Factory helper for Offline error class.
+ */
+export function createOffline(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "Offline", message, ...extra });
+}
+
+/**
+ * Factory helper for AuthError error class.
+ */
+export function createAuthError(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "AuthError", message, ...extra });
+}
+
+/**
+ * Factory helper for RateLimited error class.
+ */
+export function createRateLimited(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "RateLimited", message, ...extra });
+}
+
+/**
+ * Factory helper for Timeout error class.
+ */
+export function createTimeout(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "Timeout", message, ...extra });
+}
+
+/**
+ * Factory helper for Unavailable error class.
+ */
+export function createUnavailable(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "Unavailable", message, ...extra });
+}
+
+/**
+ * Factory helper for Internal error class.
+ */
+export function createInternal(
+  message: string,
+  extra?: Omit<IndeRunExceptionParams, "errorClass" | "message">
+): IndeRunException {
+  return new IndeRunException({ errorClass: "Internal", message, ...extra });
+}
+
+/**
+ * Standardizes any caught error into an IndeRunException.
+ * If the input error is already an IndeRunException, merges additional fallback parameters (like totalMs).
+ */
+export function toIndeRunException(
+  error: unknown,
+  fallbackParams?: Partial<Omit<IndeRunExceptionParams, "message">>
+): IndeRunException {
+  if (error instanceof IndeRunException) {
+    if (fallbackParams) {
+      const mergedParams: IndeRunExceptionParams = {
+        errorClass: error.errorClass,
+        message: error.message,
+      };
+      
+      const runId = error.runId ?? fallbackParams.runId;
+      if (runId !== undefined) mergedParams.runId = runId;
+      
+      const providerId = error.providerId ?? fallbackParams.providerId;
+      if (providerId !== undefined) mergedParams.providerId = providerId;
+      
+      const retryable = error.retryable ?? fallbackParams.retryable;
+      if (retryable !== undefined) mergedParams.retryable = retryable;
+      
+      const retryAfterMs = error.retryAfterMs ?? fallbackParams.retryAfterMs;
+      if (retryAfterMs !== undefined) mergedParams.retryAfterMs = retryAfterMs;
+      
+      if (error.details !== undefined || fallbackParams.details !== undefined) {
+        mergedParams.details = {
+          ...(error.details || {}),
+          ...(fallbackParams.details || {})
+        };
+      }
+
+      return new IndeRunException(mergedParams);
+    }
+    return error;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const details: Record<string, unknown> = {
+    ...(fallbackParams?.details || {})
+  };
+  
+  if (error instanceof Error) {
+    details.originalError = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack
+    };
+  } else {
+    details.originalError = {
+      message: String(error)
+    };
+  }
+
+  return new IndeRunException({
+    errorClass: "Internal",
+    message,
+    ...fallbackParams,
+    details
+  });
+}

--- a/packages/inderun-web/src/host.ts
+++ b/packages/inderun-web/src/host.ts
@@ -1,0 +1,84 @@
+/**
+ * Service to inspect and monitor network connectivity status.
+ */
+export interface ConnectivityService {
+  /**
+   * Resolves to true if the host is connected to the network, false otherwise.
+   */
+  isOnline(): Promise<boolean>;
+}
+
+/**
+ * Operating system thermal states denoting system heat and throttling risk.
+ */
+export type ThermalState = "nominal" | "fair" | "serious" | "critical";
+
+/**
+ * Service to inspect host device battery, power, and thermal constraints.
+ */
+export interface DeviceConstraintsService {
+  /**
+   * Retrieves the current thermal state of the device, if supported.
+   */
+  getThermalState?(): Promise<ThermalState>;
+  /**
+   * Checks if the host device has low power mode enabled, if supported.
+   */
+  isLowPowerModeEnabled?(): Promise<boolean>;
+}
+
+/**
+ * Secure storage interface to store and retrieve sensitive credentials/tokens
+ * without exposing them to request payloads.
+ */
+export interface SecureStorageService {
+  /**
+   * Gets a secret by its unique slot identifier.
+   */
+  getSecret?(slotId: string): Promise<string | null>;
+  /**
+   * Securely saves a secret under a unique slot identifier.
+   */
+  setSecret?(slotId: string, secret: string): Promise<void>;
+  /**
+   * Deletes a secret by its slot identifier.
+   */
+  deleteSecret?(slotId: string): Promise<void>;
+}
+
+/**
+ * Service providing clocks for request timeouts and execution timing telemetry.
+ */
+export interface ClockService {
+  /**
+   * Returns current UNIX timestamp in milliseconds.
+   */
+  now(): number;
+  /**
+   * Returns monotonic high-resolution time in milliseconds.
+   */
+  monotonicNow?(): number;
+}
+
+/**
+ * Registry of platform-specific host services utilized by the Engine Core.
+ * Evaluates execution capabilities and manages OS-level boundaries.
+ */
+export interface HostServices {
+  /**
+   * Network connectivity service.
+   */
+  connectivity: ConnectivityService;
+  /**
+   * Device constraints service.
+   */
+  deviceConstraints?: DeviceConstraintsService;
+  /**
+   * Secure storage service.
+   */
+  secureStorage?: SecureStorageService;
+  /**
+   * Clock service.
+   */
+  clock?: ClockService;
+}

--- a/packages/inderun-web/src/index.ts
+++ b/packages/inderun-web/src/index.ts
@@ -1,0 +1,34 @@
+export {
+  type ConnectivityService,
+  type DeviceConstraintsService,
+  type SecureStorageService,
+  type ClockService,
+  type HostServices,
+  type ThermalState
+} from "./host.js";
+
+export {
+  type ProviderDescriptor,
+  type ProviderDynamicCapabilities,
+  type RunContext,
+  type ProviderAdapter
+} from "./provider.js";
+
+export { ProviderRegistry } from "./registry.js";
+
+export { type RouteSelection, Router } from "./router.js";
+
+export {
+  type IndeRunExceptionParams,
+  IndeRunException,
+  createCapabilityMismatch,
+  createOffline,
+  createAuthError,
+  createRateLimited,
+  createTimeout,
+  createUnavailable,
+  createInternal,
+  toIndeRunException
+} from "./errors.js";
+
+export { IndeRun } from "./engine.js";

--- a/packages/inderun-web/src/provider.ts
+++ b/packages/inderun-web/src/provider.ts
@@ -1,0 +1,121 @@
+import type { TaskRequest, TaskResult } from "@independo/inderun-contracts";
+import type { HostServices } from "./host.js";
+
+/**
+ * Static metadata descriptor defining the capabilities, requirements, and constraints
+ * of a provider. This is used by the PolicyEngine and Router to select candidate providers.
+ */
+export interface ProviderDescriptor {
+  /**
+   * Unique identifier of the provider (e.g., 'openai', 'apple-foundation-models').
+   */
+  id: string;
+  /**
+   * Execution target type: 'local' (on-device), 'edge', or 'cloud'.
+   */
+  type: "local" | "edge" | "cloud";
+  /**
+   * Connection transport layer protocol.
+   */
+  transport: "in_process" | "system_service" | "http" | "sse" | "realtime";
+  /**
+   * Optional streaming style, if token or chunk streaming is supported.
+   */
+  streamingStyle?: "tokens" | "chunks" | "snapshots";
+
+  /**
+   * Flags representing the features and modes supported by this provider.
+   */
+  supports: {
+    /** Whether the provider supports Mode 1 run (request/response). */
+    run: boolean;
+    /** Whether the provider supports Mode 2 stream. */
+    streaming: boolean;
+    /** Whether the provider supports Mode 3 realtime session. */
+    realtime: boolean;
+    /** Whether the provider supports tool calling definition. */
+    tools: boolean;
+    /** Whether the provider outputs reasoning events alongside contents. */
+    reasoningEvents: boolean;
+    /** Whether the provider supports structured outputs (JSON schema constraints). */
+    structuredOutput: boolean;
+    /** Whether the provider supports multimodal inputs (images, audio, etc.). */
+    multimodal: boolean;
+  };
+
+  /**
+   * Cancellation capabilities support:
+   * - 'hard': fully stops processing and interrupts remote operations.
+   * - 'soft': stops reading the stream locally, but the remote execution continues.
+   * - 'none': cancellation is unsupported.
+   */
+  cancel: "hard" | "soft" | "none";
+
+  /**
+   * List of supported task kinds (e.g., 'text_to_text', 'embeddings').
+   */
+  tasks: string[];
+
+  /**
+   * Optional input/output resource boundaries.
+   */
+  limits?: {
+    maxInputTokens?: number;
+    maxOutputTokens?: number;
+    maxImageBytes?: number;
+    maxAudioSeconds?: number;
+  };
+
+  /**
+   * Privacy settings regarding data egress.
+   */
+  privacy?: {
+    /** Set to true if the model input leaves the host device. */
+    dataLeavesDevice: boolean;
+    /** Geographic regions where the cloud service executes. */
+    regions?: string[];
+  };
+}
+
+/**
+ * Dynamic capability snapshot evaluated at runtime.
+ */
+export interface ProviderDynamicCapabilities {
+  /**
+   * Whether the provider is available and functional on the host device now.
+   */
+  available: boolean;
+  /**
+   * Detail message if availability check fails.
+   */
+  reason?: string;
+}
+
+/**
+ * Execution context passed to provider run commands.
+ */
+export interface RunContext {
+  /**
+   * Unique execution run ID.
+   */
+  runId: string;
+}
+
+/**
+ * Pluggable execution adapter contract that wraps a specific model runtime
+ * (system frameworks, local runtimes, or cloud APIs) and exposes normalized APIs.
+ */
+export interface ProviderAdapter {
+  /**
+   * Returns static provider descriptor metadata.
+   */
+  describe(): ProviderDescriptor;
+  /**
+   * Performs dynamic capability check to determine if the provider can execute now.
+   */
+  capabilities(host: HostServices): Promise<ProviderDynamicCapabilities>;
+  /**
+   * Executes a task request in Mode 1 (request/response).
+   */
+  run(req: TaskRequest, ctx: RunContext): Promise<TaskResult>;
+}

--- a/packages/inderun-web/src/registry.ts
+++ b/packages/inderun-web/src/registry.ts
@@ -1,0 +1,48 @@
+import type { ProviderAdapter } from "./provider.js";
+
+/**
+ * Registry class that holds and manages all active ProviderAdapter instances.
+ * Loaded adapters are queried by the Router to choose appropriate routes.
+ */
+export class ProviderRegistry {
+  private providers = new Map<string, ProviderAdapter>();
+
+  /**
+   * Registers a provider adapter in the registry.
+   * @param provider - The provider adapter instance to register.
+   * @throws {Error} If the provider does not have a valid ID.
+   * @throws {Error} If another provider is already registered with the same ID.
+   */
+  register(provider: ProviderAdapter): void {
+    const descriptor = provider.describe();
+    if (!descriptor.id) {
+      throw new Error("Provider must have a non-empty ID.");
+    }
+    if (this.providers.has(descriptor.id)) {
+      throw new Error(`Provider with ID "${descriptor.id}" is already registered.`);
+    }
+    this.providers.set(descriptor.id, provider);
+  }
+
+  /**
+   * Retrieves a registered provider by its ID.
+   * @param id - Unique provider identifier.
+   */
+  get(id: string): ProviderAdapter | undefined {
+    return this.providers.get(id);
+  }
+
+  /**
+   * Returns a list of all registered provider adapters.
+   */
+  list(): ProviderAdapter[] {
+    return Array.from(this.providers.values());
+  }
+
+  /**
+   * Clears all registered providers.
+   */
+  clear(): void {
+    this.providers.clear();
+  }
+}

--- a/packages/inderun-web/src/router.ts
+++ b/packages/inderun-web/src/router.ts
@@ -1,0 +1,121 @@
+import type { TaskRequest } from "@independo/inderun-contracts";
+import type { HostServices } from "./host.js";
+import type { ProviderAdapter } from "./provider.js";
+import type { ProviderRegistry } from "./registry.js";
+import { createCapabilityMismatch, createOffline, createUnavailable } from "./errors.js";
+
+/**
+ * Output structure from the Router containing the chosen provider and a route selection description.
+ */
+export interface RouteSelection {
+  /**
+   * The selected provider adapter to run.
+   */
+  provider: ProviderAdapter;
+  /**
+   * Explanation detailing the selection decision. Useful for debugging and telemetry.
+   */
+  explanation: string;
+}
+
+/**
+ * Routing engine module. Filters registered providers against task types, execution policies,
+ * and dynamic host capabilities (such as connectivity and battery/thermal constraints)
+ * to output deterministic execution pathways.
+ */
+export class Router {
+  constructor(private registry: ProviderRegistry) {}
+
+  /**
+   * Selects an optimal and compatible execution provider based on the task request and host conditions.
+   * @param request - The canonical task request payload.
+   * @param hostServices - Host services containing network status and hardware indicators.
+   * @returns Resolves to the selected RouteSelection object.
+   * @throws {IndeRunException} Under the following routing failure rules:
+   *  - `CapabilityMismatch` when `execution === 'on_device'` but no local provider is registered or available.
+   *  - `Offline` when `execution === 'cloud'` but the device lacks internet connectivity.
+   *  - `Unavailable` when `execution === 'cloud'` but no cloud provider is registered or functional.
+   */
+  async selectRoute(
+    request: TaskRequest,
+    hostServices: HostServices
+  ): Promise<RouteSelection> {
+    const taskKind = request.task.kind;
+    const executionPolicy = request.policy.execution;
+
+    // 1. Map, sort, and filter candidate providers stably by ID to ensure deterministic selection
+    const candidates = this.registry.list().map((p) => ({
+      provider: p,
+      descriptor: p.describe()
+    })).sort((a, b) => a.descriptor.id.localeCompare(b.descriptor.id));
+
+    const taskCandidates = candidates.filter(
+      (c) => c.descriptor.tasks.includes(taskKind) && c.descriptor.supports.run
+    );
+
+    // 2. Route based on execution policy
+    if (executionPolicy === "on_device") {
+      const localCandidates = taskCandidates.filter(
+        (c) => c.descriptor.type === "local"
+      );
+
+      if (localCandidates.length === 0) {
+        throw createCapabilityMismatch(
+          `Capability mismatch: no on-device provider found supporting task '${taskKind}'.`
+        );
+      }
+
+      // Check dynamic capabilities of local candidates
+      for (const candidate of localCandidates) {
+        const caps = await candidate.provider.capabilities(hostServices);
+        if (caps.available) {
+          return {
+            provider: candidate.provider,
+            explanation: `Selected on-device provider '${candidate.descriptor.id}' deterministically.`
+          };
+        }
+      }
+
+      throw createCapabilityMismatch(
+        "Capability mismatch: on-device execution selected, but on-device provider is currently unavailable."
+      );
+    } else if (executionPolicy === "cloud") {
+      // Check network status before filtering cloud providers
+      const online = await hostServices.connectivity.isOnline();
+      if (!online) {
+        throw createOffline(
+          "Offline: cloud execution selected, but no network connection is available."
+        );
+      }
+
+      const cloudCandidates = taskCandidates.filter(
+        (c) => c.descriptor.type === "cloud"
+      );
+
+      if (cloudCandidates.length === 0) {
+        throw createUnavailable(
+          `Unavailable: no cloud provider found supporting task '${taskKind}'.`
+        );
+      }
+
+      // Check dynamic capabilities of cloud candidates
+      for (const candidate of cloudCandidates) {
+        const caps = await candidate.provider.capabilities(hostServices);
+        if (caps.available) {
+          return {
+            provider: candidate.provider,
+            explanation: `Selected cloud provider '${candidate.descriptor.id}' deterministically.`
+          };
+        }
+      }
+
+      throw createUnavailable(
+        "Unavailable: cloud execution selected, but no cloud provider is currently available."
+      );
+    } else {
+      throw createCapabilityMismatch(
+        `Capability mismatch: unsupported execution policy '${executionPolicy}'.`
+      );
+    }
+  }
+}

--- a/packages/inderun-web/tsconfig.json
+++ b/packages/inderun-web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmitOnError": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/inderun-web/vitest.config.ts
+++ b/packages/inderun-web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"]
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,22 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.12.2)
 
+  packages/inderun-web:
+    dependencies:
+      '@independo/inderun-contracts':
+        specifier: workspace:^
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.12.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.12.2)
+
 packages:
 
   '@apidevtools/json-schema-ref-parser@11.9.3':


### PR DESCRIPTION
Implements ticket #2.

Introduce `packages/inderun-web/` containing:
- Abstract interfaces for host capabilities and provider adapters.
- ProviderRegistry for managing registered execution provider adapters.
- Router for deterministic routing based on policy and host connectivity.
- IndeRunException and helpers mapping to standard error taxonomy classes.
- IndeRun orchestrator managing request validation, execution, and timing telemetry.
- Comprehensive unit tests covering validation, routing rules, and error states.
- Fully documented codebase using TSDoc comments.