### PR TITLE
feat(web): implement telemetry event emission and orchestrator integr…

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -403,7 +403,11 @@ Computed per request (or per session tick) using Host Services:
 
 7) **Telemetry**
 
-- standardized spans/events, configurable levels (off/minimal/debug)
+- Standardized spans/events, configurable levels (off/minimal/debug)
+- Emits structured telemetry events via the `TelemetryService` hook interface:
+  - `route_decided`: Emitted once the Router selects a deterministic provider. Contains selected provider ID, task kind, execution policy, and routing explanation.
+  - `attempt_succeeded`: Emitted on successful provider run, detailing provider ID and elapsed duration.
+  - `attempt_failed`: Emitted on validation, routing, or provider execution errors, detailing duration, error class, and message.
 
 ### 9.2 Routing algorithm (deterministic, inspectable)
 

--- a/packages/inderun-web/src/engine.test.ts
+++ b/packages/inderun-web/src/engine.test.ts
@@ -190,8 +190,8 @@ describe("IndeRun Engine Core Skeleton Tests", () => {
       const result = await engine.run(req);
       expect(result.output.text).toBe("Mock local response: test prompt");
       expect(result.telemetry.providerUsed).toBe("mock-local-1");
-      // Timings: the mock clock is read only at start and end, so total elapsed time is one 50ms increment.
-      expect(result.telemetry.totalMs).toBe(50);
+      // Timings: mock clock is read at start, route_decided emission, and end telemetry (total 3 reads).
+      expect(result.telemetry.totalMs).toBe(100);
     });
 
     it("ensures the result runId matches the engine's runId", async () => {
@@ -284,7 +284,7 @@ describe("IndeRun Engine Core Skeleton Tests", () => {
       const result = await engine.run(req);
       expect(result.output.text).toBe("Mock cloud response: test prompt");
       expect(result.telemetry.providerUsed).toBe("mock-cloud-1");
-      expect(result.telemetry.totalMs).toBe(50);
+      expect(result.telemetry.totalMs).toBe(100);
     });
 
     it("throws Offline if cloud execution is selected but the device is offline", async () => {
@@ -364,6 +364,171 @@ describe("IndeRun Engine Core Skeleton Tests", () => {
         const exception = err as IndeRunException;
         expect(exception.errorClass).toBe("Unavailable");
       }
+    });
+  });
+
+  describe("Telemetry Event Emission", () => {
+    class MockTelemetryService {
+      public events: any[] = [];
+      emit(event: any) {
+        this.events.push(event);
+      }
+    }
+
+    it("emits route_decided and attempt_succeeded on successful run", async () => {
+      const provider = createMockLocalProvider("mock-local-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const telemetry = new MockTelemetryService();
+      const engine = new IndeRun(registry, host, telemetry);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "hello telemetry",
+        policy: { execution: "on_device" },
+        requestId: "test-run-1"
+      };
+
+      await engine.run(req);
+
+      expect(telemetry.events).toHaveLength(2);
+      expect(telemetry.events[0]).toMatchObject({
+        type: "route_decided",
+        runId: "test-run-1",
+        payload: {
+          selectedProviderId: "mock-local-1",
+          executionPolicy: "on_device",
+          taskKind: "text_to_text"
+        }
+      });
+      expect(telemetry.events[1]).toMatchObject({
+        type: "attempt_succeeded",
+        runId: "test-run-1",
+        payload: {
+          providerId: "mock-local-1",
+          durationMs: 100
+        }
+      });
+    });
+
+    it("emits attempt_failed on routing failure (e.g. offline)", async () => {
+      const provider = createMockCloudProvider("mock-cloud-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(false); // offline
+      const telemetry = new MockTelemetryService();
+      const engine = new IndeRun(registry, host, telemetry);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "hello telemetry fail",
+        policy: { execution: "cloud" },
+        requestId: "test-run-fail"
+      };
+
+      await expect(engine.run(req)).rejects.toThrow();
+
+      expect(telemetry.events).toHaveLength(1);
+      expect(telemetry.events[0]).toMatchObject({
+        type: "attempt_failed",
+        runId: "test-run-fail",
+        payload: {
+          providerId: null, // no provider selected since offline routing failed early
+          durationMs: 50,
+          errorClass: "Offline",
+          message: "Device is offline."
+        }
+      });
+    });
+
+    it("emits route_decided and attempt_failed if provider execution throws", async () => {
+      const failingProvider: ProviderAdapter = {
+        describe() {
+          return {
+            id: "failing-provider",
+            type: "local",
+            transport: "system_service",
+            supports: {
+              run: true,
+              streaming: false,
+              realtime: false,
+              tools: false,
+              reasoningEvents: false,
+              structuredOutput: false,
+              multimodal: false
+            },
+            cancel: "none",
+            tasks: ["text_to_text"]
+          };
+        },
+        async capabilities() {
+          return { available: true };
+        },
+        async run() {
+          throw new Error("Simulated provider failure");
+        }
+      };
+      registry.register(failingProvider);
+
+      const host = createMockHostServices(true);
+      const telemetry = new MockTelemetryService();
+      const engine = new IndeRun(registry, host, telemetry);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "hello provider fail",
+        policy: { execution: "on_device" },
+        requestId: "test-run-provider-fail"
+      };
+
+      await expect(engine.run(req)).rejects.toThrow();
+
+      expect(telemetry.events).toHaveLength(2);
+      expect(telemetry.events[0]).toMatchObject({
+        type: "route_decided",
+        runId: "test-run-provider-fail",
+        payload: {
+          selectedProviderId: "failing-provider"
+        }
+      });
+      expect(telemetry.events[1]).toMatchObject({
+        type: "attempt_failed",
+        runId: "test-run-provider-fail",
+        payload: {
+          providerId: "failing-provider",
+          durationMs: 100,
+          errorClass: "Internal",
+          message: "An internal engine error occurred."
+        }
+      });
+    });
+
+    it("does not fail execution if the telemetry service emit throws an error", async () => {
+      const provider = createMockLocalProvider("mock-local-1", true);
+      registry.register(provider);
+
+      const host = createMockHostServices(true);
+      const throwingTelemetry = {
+        emit() {
+          throw new Error("Simulated telemetry service failure");
+        }
+      };
+      const engine = new IndeRun(registry, host, throwingTelemetry);
+
+      const req: TaskRequest = {
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "hello telemetry throw",
+        policy: { execution: "on_device" }
+      };
+
+      // Execution should complete successfully even if emit throws
+      const result = await engine.run(req);
+      expect(result.output.text).toBe("Mock local response: hello telemetry throw");
     });
   });
 });

--- a/packages/inderun-web/src/engine.ts
+++ b/packages/inderun-web/src/engine.ts
@@ -7,6 +7,11 @@ import type { HostServices } from "./host.js";
 import { ProviderRegistry } from "./registry.js";
 import { Router } from "./router.js";
 import { createInternal, toIndeRunException } from "./errors.js";
+import {
+  type TelemetryEvent,
+  type TelemetryService,
+  NoOpTelemetryService
+} from "./telemetry.js";
 
 /**
  * Main orchestrator SDK entrypoint class.
@@ -15,17 +20,61 @@ import { createInternal, toIndeRunException } from "./errors.js";
  */
 export class IndeRun {
   private router: Router;
+  private telemetryService: TelemetryService;
 
   /**
    * Initializes the IndeRun instance.
    * @param registry - Registry filled with active providers.
    * @param hostServices - Services wrapping OS interfaces and indicators.
+   * @param telemetryService - Optional custom telemetry service listener.
    */
   constructor(
     private registry: ProviderRegistry,
-    private hostServices: HostServices
+    private hostServices: HostServices,
+    telemetryService?: TelemetryService
   ) {
     this.router = new Router(this.registry);
+    this.telemetryService =
+      telemetryService ||
+      this.hostServices.telemetry ||
+      new NoOpTelemetryService();
+  }
+
+  /**
+   * Safely emits a telemetry event by swallowing any internal logging/telemetry system errors.
+   * @param event - The telemetry event to emit.
+   */
+  private safeEmit(event: TelemetryEvent): void {
+    try {
+      this.telemetryService.emit(event);
+    } catch (err) {
+      // Telemetry failures must never disrupt primary execution flows.
+      console.warn("[IndeRun] Telemetry service emission failed:", err);
+    }
+  }
+
+  /**
+   * Returns a stable, generic description of an error class for privacy-preserving telemetry.
+   * @param errorClass - The taxonomy classification of the exception.
+   */
+  private getStableMessage(errorClass: string): string {
+    switch (errorClass) {
+      case "CapabilityMismatch":
+        return "Provider capability mismatch.";
+      case "Offline":
+        return "Device is offline.";
+      case "AuthError":
+        return "Authentication failed.";
+      case "RateLimited":
+        return "Rate limit exceeded.";
+      case "Timeout":
+        return "Execution timed out.";
+      case "Unavailable":
+        return "Provider is unavailable.";
+      case "Internal":
+      default:
+        return "An internal engine error occurred.";
+    }
   }
 
   /**
@@ -65,6 +114,19 @@ export class IndeRun {
       );
       const provider = routeSelection.provider;
 
+      // Emit route_decided event
+      this.safeEmit({
+        type: "route_decided",
+        runId,
+        timestamp: this.hostServices.clock ? this.hostServices.clock.now() : Date.now(),
+        payload: {
+          selectedProviderId: provider.describe().id,
+          executionPolicy: request.policy.execution,
+          taskKind: request.task.kind,
+          explanation: routeSelection.explanation
+        }
+      });
+
       // 3. Execute the run task on the selected provider
       let result: TaskResult;
       try {
@@ -93,6 +155,17 @@ export class IndeRun {
         totalMs
       };
 
+      // Emit attempt_succeeded event
+      this.safeEmit({
+        type: "attempt_succeeded",
+        runId,
+        timestamp: endTime,
+        payload: {
+          providerId: provider.describe().id,
+          durationMs: totalMs
+        }
+      });
+
       return result;
     } catch (err) {
       const endTime = this.hostServices.clock
@@ -103,6 +176,19 @@ export class IndeRun {
       const exception = toIndeRunException(err, {
         runId,
         details: { totalMs }
+      });
+
+      // Emit attempt_failed event
+      this.safeEmit({
+        type: "attempt_failed",
+        runId,
+        timestamp: endTime,
+        payload: {
+          providerId: exception.providerId ?? null,
+          durationMs: totalMs,
+          errorClass: exception.errorClass,
+          message: this.getStableMessage(exception.errorClass)
+        }
       });
 
       throw exception;

--- a/packages/inderun-web/src/host.ts
+++ b/packages/inderun-web/src/host.ts
@@ -1,3 +1,5 @@
+import type { TelemetryService } from "./telemetry.js";
+
 /**
  * Service to inspect and monitor network connectivity status.
  */
@@ -81,4 +83,8 @@ export interface HostServices {
    * Clock service.
    */
   clock?: ClockService;
+  /**
+   * Telemetry service to monitor execution steps, latency, and success rates.
+   */
+  telemetry?: TelemetryService;
 }

--- a/packages/inderun-web/src/index.ts
+++ b/packages/inderun-web/src/index.ts
@@ -32,3 +32,10 @@ export {
 } from "./errors.js";
 
 export { IndeRun } from "./engine.js";
+
+export {
+  type TelemetryEventType,
+  type TelemetryEvent,
+  type TelemetryService,
+  NoOpTelemetryService
+} from "./telemetry.js";

--- a/packages/inderun-web/src/telemetry.ts
+++ b/packages/inderun-web/src/telemetry.ts
@@ -1,0 +1,56 @@
+/**
+ * Types of telemetry events emitted by the orchestrator.
+ * - 'route_decided': Fired once the routing engine resolves a candidate provider.
+ * - 'attempt_succeeded': Fired when the selected provider runs and returns successfully.
+ * - 'attempt_failed': Fired if the orchestrator fails at validation, routing, or provider execution.
+ */
+export type TelemetryEventType =
+  | "route_decided"
+  | "attempt_succeeded"
+  | "attempt_failed";
+
+/**
+ * Normalized telemetry event structure emitted by the orchestrator.
+ */
+export interface TelemetryEvent {
+  /**
+   * The type of the telemetry event.
+   */
+  type: TelemetryEventType;
+  /**
+   * Unique execution run ID.
+   */
+  runId: string;
+  /**
+   * UNIX timestamp in milliseconds when the event was generated.
+   */
+  timestamp: number;
+  /**
+   * Rich event payload details containing specific event metadata.
+   */
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Telemetry service listener hook interface.
+ */
+export interface TelemetryService {
+  /**
+   * Emits a telemetry event.
+   * @param event - The generated telemetry event.
+   */
+  emit(event: TelemetryEvent): void;
+}
+
+/**
+ * Default no-op telemetry handler that discards all events.
+ */
+export class NoOpTelemetryService implements TelemetryService {
+  /**
+   * Discards the telemetry event.
+   * @param _event - The telemetry event to discard.
+   */
+  emit(_event: TelemetryEvent): void {
+    // No-op
+  }
+}


### PR DESCRIPTION
…ation (#3)

- Define `TelemetryEvent` and `TelemetryService` interfaces with `NoOpTelemetryService` default.
- Integrate the telemetry service hook into `HostServices` and `IndeRun` orchestrator.
- Emit `route_decided`, `attempt_succeeded`, and `attempt_failed` events at key stages of task execution.
- Update architecture documentation to document the new telemetry event types.
- Add unit tests verifying telemetry event types, payloads, and timing behaviors.