### PR TITLE
feat(web): implement ONNX Runtime provider for Web (#85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ tmp
 test_repo/
 test_dir/
 .pnpm-store/
+
+# Local env overrides
+.env.local

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ const result = await inderun.run({
 > Browser apps must route OpenAI calls through a same-origin proxy that keeps the key server-side — never ship
 > provider credentials to the browser.
 
+For on-device execution with a developer-supplied ONNX model, pass `onnx` as well (or instead) and
+register the Web ONNX Runtime provider — see the
+[`@independo/inderun-web` README](packages/inderun-web/README.md#on-device-models-onnx-runtime-web)
+and the [ONNX Runtime provider family](docs/architecture/onnx-runtime-provider-family.md). The
+provider ships from the `@independo/inderun-web/onnx` subpath.
+
 ### iOS / macOS (Swift)
 
 **Requirements:**
@@ -190,6 +196,7 @@ Never place raw API keys in a `TaskRequest`. Providers resolve credentials from 
 - [Project brief](docs/architecture/technical-brief.md)
 - [Architecture overview](docs/architecture/architecture.md)
 - [Provider model](docs/architecture/providers.md)
+- [ONNX Runtime provider family](docs/architecture/onnx-runtime-provider-family.md)
 - [CI behavior](docs/ci.md)
 - [Releases & publishing](docs/release.md)
 - [Contributor workflow and build commands](CONTRIBUTING.md)

--- a/docs/architecture/onnx-runtime-provider-family.md
+++ b/docs/architecture/onnx-runtime-provider-family.md
@@ -5,8 +5,9 @@ provider-neutral model-loading contract used for developer-supplied/custom local
 architecture baseline for the platform implementation tickets: #85 (Web), #87 (Android), and #86
 (Apple platforms). Those tickets implement providers; they must not re-decide the boundaries below.
 
-This is a Milestone 2 specification. It does not implement any provider. Field-level shapes live in
-the schema, not in this prose (see [Model Package Contract](#model-package-contract)).
+This is a Milestone 2 specification. Field-level shapes live in the schema, not in this prose (see
+[Model Package Contract](#model-package-contract)). The Web member is implemented; Android and Apple
+are not yet (see [Web Implementation](#web-implementation)).
 
 ## Classification And Boundaries
 
@@ -33,9 +34,10 @@ One adapter per platform, each wrapping the platform's ORT distribution:
 - Android: ORT Mobile (`onnxruntime-android`) — tracked in #87
 - Apple platforms: ORT Mobile (`onnxruntime-c` / `onnxruntime-objc`) — tracked in #86
 
-Proposed provider ids follow the existing plain-string id convention: `local.onnx.genai.web`,
-`local.onnx.genai.android`, `local.onnx.genai.apple`. Ids are a proposal and may be adjusted during
-implementation review. Every family member is `type: local` with `privacy.dataLeavesDevice: false`.
+Provider ids follow the existing plain-string id convention: `local.onnx.genai.web` (confirmed by the
+Web implementation), `local.onnx.genai.android`, `local.onnx.genai.apple`. The mobile ids remain a
+proposal until those tickets land. Every family member is `type: local` with
+`privacy.dataLeavesDevice: false`.
 
 ## Interaction Mode And Task
 
@@ -54,6 +56,15 @@ DeepSeek-R1-Distill.
 **Risk (accepted):** the ORT GenAI (`generate()`) API is documented as *"in preview and is subject
 to change"*. Implementers must isolate the GenAI call behind an injectable runtime seam (below) so a
 version change is contained in the adapter.
+
+**Correction — GenAI has no browser build.** ORT GenAI ships Python, .NET, C/C++, and Java packages
+only; there is no JavaScript/browser distribution, and `onnxruntime-web` provides raw inference
+without a generative loop (tokenization, sampling, KV cache). The Web member therefore satisfies the
+*role* GenAI was mandated for — not the literal package — by defaulting to Transformers.js, which
+runs ONNX models on `onnxruntime-web` and owns the generative loop. This is exactly what the
+injectable seam exists for: the seam is the contract, the default implementation is swappable, and
+the mobile members are unaffected and still target ORT GenAI. Source:
+<https://onnxruntime.ai/docs/genai/howto/install.html>.
 
 **Deterministic fixture fallback.** IndeRun already makes on-device adapters testable without their
 native backend via an injectable runtime interface (`AppleFoundationModelsRuntime`,
@@ -189,6 +200,73 @@ concerns.
 Family members declare `cancel: soft`, matching the other on-device adapters (Apple Foundation
 Models, ML Kit). ORT `run` is not hard-interruptible; cancellation produces a terminal cancellation
 outcome with no user-visible events after the cancel point, per `architecture.md`.
+
+## Web Implementation
+
+The Web member ships in `@independo/inderun-web` under the `./onnx` subpath entry point, kept out of
+the provider-agnostic root index like the OpenAI adapter. Provider id: `local.onnx.genai.web`.
+Descriptor: `type: local`, `transport: in_process`, `supports.run: true` with all forward-looking
+flags false, `cancel: soft`, `privacy.dataLeavesDevice: false`. Option shapes and the error table for
+consumers live in the package README, not here.
+
+**Runtime seam.** `OnnxTextGenerationRuntime` has two methods: `prepare(modelPackage)` returning the
+`{ available, reason? }` snapshot, and `generate(input, signal)` returning normalized text. Three
+implementations exist:
+
+- `createTransformersJsRuntime()` — the default. Lazily imports `@huggingface/transformers`, which the
+  application installs; IndeRun does not bundle it. Initialization failures are reported as
+  *runtime package unavailable* rather than thrown, so routing degrades to an explainable rejection
+  rather than a crash. The import specifier stays statically resolvable so bundlers can find the
+  package; apps that do not install it supply their own runtime instead.
+- `createFixtureOnnxRuntime()` — the deterministic in-memory fixture mandated above. It is the test
+  seam and lets demos exercise the on-device route offline.
+- Any application-supplied implementation, for example a hand-rolled `onnxruntime-web` pipeline.
+
+Runtime failures are signalled with `OnnxRuntimeError`, whose `kind` (`capability`, `unavailable`,
+`timeout`, `internal`) selects the IndeRun error class per the mapping table above; anything else a
+runtime throws normalizes to `Internal`. Allocation failures during model load (ONNX Runtime reports
+these as `std::bad_alloc` from session creation) are resource exhaustion and map to `Unavailable`,
+not `CapabilityMismatch`.
+
+The default runtime loads quantized weights (`q4f16` on WebGPU, `q4` otherwise) because
+Transformers.js would otherwise select `fp32` and exhaust browser memory. It covers models that load
+through the `text-generation` pipeline, which is the Mode 1 `text_to_text` case this family targets.
+Multimodal exports are split across separate vision/audio/embedding/decoder graphs and need
+`AutoProcessor` plus a model-specific class; that is out of scope for `text_to_text` and, if ever
+needed, belongs in a custom runtime behind the seam rather than in the provider.
+
+**Model sources.** The Web member honors `registry`, `bundled`, `programmatic`, and `app_managed` and
+rejects the other two in `capabilities()`, matching the matrix above: `filesystem` as unsupported
+(browsers cannot read arbitrary local paths) and `remote` as deferred (the host downloads and then
+re-declares the files). The Transformers.js runtime maps `registry` refs to hub model ids, points the
+loader at locally served assets for `bundled`/`app_managed`, and requires an application-supplied
+generator for `programmatic`.
+
+**Capability gate order.** Model package schema validation (reusing `getModelPackageValidationIssues`
+from the contracts package, including its inline-secret and URL-userinfo rules) → Web source-type
+support → `runtime.platforms` includes `web` → declared tasks include `text_to_text` → delegate to
+`runtime.prepare`. Every failure flattens to one `capability_unavailable` route rejection carrying
+the reason string, for example:
+
+- `capability_unavailable`: *model source unavailable: 'filesystem' model sources are unsupported on
+  Web because browsers cannot read arbitrary local paths.*
+- `capability_unavailable`: *runtime package unavailable: install the optional dependency
+  @huggingface/transformers (…).*
+- `CapabilityMismatch` at run time when the same gate fails pre-attempt; `Timeout` when the
+  generation budget (`constraints.timeoutMs`, else the provider's `timeoutMs`) elapses; `Unavailable`
+  for runtime initialization failures and resource exhaustion. There is no `AuthError`,
+  `RateLimited`, or `Offline` path.
+
+**Browser constraints.** WASM is the CPU baseline; WebGPU is used when `navigator.gpu` exists.
+Backend choice is an internal detail surfaced only in capability `reason` strings — never a routing
+target. WASM threads require cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: require-corp`), and the host application is responsible for serving
+and caching model and ORT WASM assets; IndeRun owns no download or cache layer in Milestone 2.
+
+**Authoring a custom local provider.** Implement `OnnxTextGenerationRuntime` rather than a new
+`ProviderAdapter` when the model is ONNX: the provider already owns descriptor semantics, model
+package validation, source gating, timeouts, and error normalization. Implement `ProviderAdapter`
+directly only for a different runtime family.
 
 ## Documentation Requirements For Platform Tickets (#85–#87)
 

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -39,8 +39,9 @@ factories), not in prose.
 - Android on-device: ML Kit GenAI provider
 - Web and native cloud: OpenAI-compatible provider
 - Custom/developer-supplied local models: ONNX Runtime provider family (Milestone 2, specified in
-  [onnx-runtime-provider-family.md](onnx-runtime-provider-family.md); implementation tracked in
-  #85/#86/#87)
+  [onnx-runtime-provider-family.md](onnx-runtime-provider-family.md))
+  - Web on-device: `local.onnx.genai.web`, shipped in `@independo/inderun-web/onnx`
+  - Android and Apple members are not implemented yet (#87/#86)
 - Shared route planning: Rust core used by the TypeScript/Web side and WASM wrapper
 
 ## Current Guidance

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -34,6 +34,8 @@ export {
 export type {
   FinishReason,
   IndeRunErrorClass,
+  ModelPackageFormat,
+  ModelSourceType,
   SchemaVersion,
   SharedRoutePlan,
   SharedRoutePlannerInput,

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   IndeRunError,
+  ModelPackage,
   RoutePlan,
   RoutePlannerInput,
   TaskRequest,
@@ -25,3 +26,7 @@ export type SharedRoutePlan = RoutePlan;
 export type RoutingConstraints = NonNullable<TaskRequest["constraints"]>;
 /** Routing preferences (e.g. `optimizeFor`) from a task request. */
 export type RoutingPreferences = NonNullable<TaskRequest["preferences"]>;
+/** Serialization format of a model package (`onnx`, `ort`, `genai`). */
+export type ModelPackageFormat = ModelPackage["format"];
+/** How a model package's files are supplied to a provider (`registry`, `bundled`, ...). */
+export type ModelSourceType = NonNullable<ModelPackage["source"]>["sourceType"];

--- a/packages/inderun-web-demo/README.md
+++ b/packages/inderun-web-demo/README.md
@@ -1,8 +1,34 @@
 # IndeRun Web Demo
 
-Minimal browser demo for the Mode 1 cloud flow.
+Minimal browser demo for the Mode 1 cloud and on-device flows.
 
 It runs a prompt through `@independo/inderun-web`, shows either generated text or a normalized error, and surfaces the run metadata returned by the SDK.
+
+## Execution Modes
+
+**On Device** (the default mode) routes with `privacy: "local_required"` through the Web ONNX
+Runtime provider (`local.onnx.genai.web`). **Cloud** routes with `privacy: "cloud_required"` through
+the demo proxy.
+
+Without `VITE_INDERUN_ONNX_MODEL_ID` the on-device mode uses the deterministic fixture runtime, so
+the local route works offline and in CI without downloading model weights. Set it to run real
+weights; that also requires installing `@huggingface/transformers`.
+
+| Env var                              | Effect                                                     |
+| ------------------------------------ | ---------------------------------------------------------- |
+| `VITE_INDERUN_ONNX_MODEL_ID`         | Hub model ref; switches on-device mode to a real runtime    |
+| `VITE_INDERUN_ONNX_MODEL_PACKAGE_ID` | Model package id reported by the provider (cosmetic)        |
+| `VITE_INDERUN_OPENAI_MODEL`          | Cloud model id                                              |
+| `VITE_INDERUN_DEMO_PROXY_URL`        | Proxy endpoint for the cloud route                          |
+
+Suggested model: `onnx-community/gemma-3-1b-it-ONNX` — text-only, single-graph, and loadable through
+the `text-generation` pipeline the default runtime uses. At the default `q4f16` it downloads roughly
+700 MB on first run and is cached afterwards. `onnx-community/LFM2.5-350M-ONNX` is a lighter
+alternative.
+
+Multimodal exports (Gemma 4's `any-to-any` E2B/E4B, for example) are split across separate
+vision/audio/decoder graphs and do **not** load through that pipeline; they would need a custom
+`OnnxTextGenerationRuntime`.
 
 ## Security Model
 
@@ -21,4 +47,4 @@ pnpm --filter @independo/inderun-web-demo test
 
 1. Start `@independo/inderun-demo-proxy`.
 2. Start this demo.
-3. Open the local Vite URL and run a prompt.
+3. Open the local Vite URL and run a prompt in both **Cloud** and **On Device** mode.

--- a/packages/inderun-web-demo/package.json
+++ b/packages/inderun-web-demo/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "@independo/inderun-contracts": "workspace:^",
     "@independo/inderun-web": "workspace:^"
   },

--- a/packages/inderun-web-demo/src/app.test.ts
+++ b/packages/inderun-web-demo/src/app.test.ts
@@ -29,14 +29,14 @@ describe("mountApp", () => {
       runPrompt
     });
 
-    const prompt = root.querySelector<HTMLTextAreaElement>("#prompt");
-    const button = root.querySelector<HTMLButtonElement>("#run-button");
-    if (!prompt || !button) {
-      throw new Error("Expected prompt and button.");
+    root.querySelector<HTMLButtonElement>("#mode-cloud")?.click();
+    const cloudPrompt = root.querySelector<HTMLTextAreaElement>("#prompt");
+    if (!cloudPrompt) {
+      throw new Error("Expected prompt field after mode switch.");
     }
 
-    prompt.value = "Test prompt";
-    button.click();
+    cloudPrompt.value = "Test prompt";
+    root.querySelector<HTMLButtonElement>("#run-button")?.click();
     await Promise.resolve();
     await Promise.resolve();
 
@@ -44,6 +44,51 @@ describe("mountApp", () => {
     expect(root.textContent).toContain("Routed through the cloud provider.");
     expect(root.textContent).toContain("openai");
     expect(root.textContent).toContain("42 ms");
+  });
+
+  it("runs the on-device mode against the local provider and shows the on-device model", async () => {
+    document.body.innerHTML = `<div id="app"></div>`;
+    const root = document.querySelector<HTMLElement>("#app");
+    if (!root) {
+      throw new Error("Missing app root for test.");
+    }
+
+    const runPrompt = vi.fn().mockResolvedValue({
+      schemaVersion: "1.0",
+      runId: "run_local",
+      output: { type: "text", text: "[fixture:inderun-demo-fixture] Test prompt" },
+      finishReason: "stop",
+      telemetry: {
+        providerUsed: "local.onnx.genai.web",
+        totalMs: 7
+      }
+    });
+
+    mountApp(root, {
+      config: {
+        model: "gemma4:latest",
+        proxyEndpointUrl: "/api/inderun/openai-responses",
+        onDeviceModel: "deterministic fixture runtime"
+      },
+      runPrompt
+    });
+
+    root.querySelector<HTMLButtonElement>("#mode-on-device")?.click();
+
+    const prompt = root.querySelector<HTMLTextAreaElement>("#prompt");
+    if (!prompt) {
+      throw new Error("Expected prompt field.");
+    }
+    prompt.value = "Test prompt";
+
+    expect(root.textContent).toContain("deterministic fixture runtime");
+
+    root.querySelector<HTMLButtonElement>("#run-button")?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runPrompt).toHaveBeenCalledWith("Test prompt", "on_device");
+    expect(root.textContent).toContain("local.onnx.genai.web");
   });
 
   it("renders normalized IndeRun errors", async () => {

--- a/packages/inderun-web-demo/src/app.ts
+++ b/packages/inderun-web-demo/src/app.ts
@@ -8,6 +8,8 @@ export interface AppDependencies {
   config: {
     model: string;
     proxyEndpointUrl: string;
+    /** Model reference backing the on-device ONNX provider, when configured. */
+    onDeviceModel?: string;
   };
   runPrompt(prompt: string, executionMode: "on_device" | "cloud"): Promise<TaskResult>;
 }
@@ -37,7 +39,7 @@ export function mountApp(root: HTMLElement, deps: AppDependencies): void {
   let state: AppState = {
     status: "idle",
     prompt: DEFAULT_PROMPT,
-    executionMode: "cloud"
+    executionMode: "on_device"
   };
 
   const render = () => {
@@ -75,7 +77,13 @@ export function mountApp(root: HTMLElement, deps: AppDependencies): void {
             <button id="run-button" type="button" ${state.status === "running" ? "disabled" : ""}>
               ${state.status === "running" ? "Running..." : state.executionMode === "on_device" ? "Run On Device" : "Run Through Cloud"}
             </button>
-            <p class="hint">Endpoint: <code class="code">${escapeHtml(deps.config.proxyEndpointUrl)}</code></p>
+            <p class="hint">
+              ${
+                state.executionMode === "on_device"
+                  ? `On-device model: <code class="code">${escapeHtml(deps.config.onDeviceModel ?? "not configured")}</code>`
+                  : `Endpoint: <code class="code">${escapeHtml(deps.config.proxyEndpointUrl)}</code>`
+              }
+            </p>
           </div>
         </section>
 
@@ -94,7 +102,7 @@ export function mountApp(root: HTMLElement, deps: AppDependencies): void {
         <section class="panel limitations">
           <h2 class="subtitle">Known Limitations</h2>
           <ul>
-            <li>On-device routing requires a local provider setup that matches the request constraints.</li>
+            <li>On-device routing uses the Web ONNX Runtime provider. Without <code class="code">VITE_INDERUN_ONNX_MODEL_ID</code> it runs a deterministic fixture runtime instead of real model weights.</li>
             <li>The browser never carries production secrets. The standalone demo proxy resolves upstream endpoint and bearer-token configuration server-side.</li>
             <li>The canonical result field is <code class="code">telemetry.totalMs</code>, not <code class="timing">timing.totalMs</code>.</li>
           </ul>

--- a/packages/inderun-web-demo/src/config.ts
+++ b/packages/inderun-web-demo/src/config.ts
@@ -1,5 +1,6 @@
 const DEFAULT_DEMO_PROXY_ENDPOINT_URL = "/api/inderun/openai-responses";
 const DEFAULT_OPENAI_MODEL = "gpt-5.2";
+const DEFAULT_ONNX_MODEL_PACKAGE_ID = "inderun-demo-fixture";
 
 export function getDemoProxyEndpointUrl(env: ImportMetaEnv = import.meta.env): string {
   return env.VITE_INDERUN_DEMO_PROXY_URL ?? DEFAULT_DEMO_PROXY_ENDPOINT_URL;
@@ -7,4 +8,22 @@ export function getDemoProxyEndpointUrl(env: ImportMetaEnv = import.meta.env): s
 
 export function getDemoModel(env: ImportMetaEnv = import.meta.env): string {
   return env.VITE_INDERUN_OPENAI_MODEL ?? DEFAULT_OPENAI_MODEL;
+}
+
+/**
+ * Hugging Face-style model reference for the on-device ONNX provider.
+ *
+ * When unset, the demo runs the on-device route against the deterministic fixture runtime, so the
+ * on-device path works offline and in CI without downloading model weights.
+ */
+export function getDemoOnnxModelRef(env: ImportMetaEnv = import.meta.env): string | undefined {
+  const ref = env.VITE_INDERUN_ONNX_MODEL_ID;
+  return ref !== undefined && ref.length > 0 ? ref : undefined;
+}
+
+/**
+ * Model package id reported by the on-device provider. Only cosmetic in the demo.
+ */
+export function getDemoOnnxModelPackageId(env: ImportMetaEnv = import.meta.env): string {
+  return env.VITE_INDERUN_ONNX_MODEL_PACKAGE_ID ?? DEFAULT_ONNX_MODEL_PACKAGE_ID;
 }

--- a/packages/inderun-web-demo/src/demo-client.ts
+++ b/packages/inderun-web-demo/src/demo-client.ts
@@ -1,12 +1,43 @@
-import type { TaskResult } from "@independo/inderun-contracts";
+import type { ModelPackage, TaskResult } from "@independo/inderun-contracts";
 import { createIndeRunWeb } from "@independo/inderun-web";
-import { getDemoModel, getDemoProxyEndpointUrl } from "./config";
+import {
+  createFixtureOnnxRuntime,
+  createTransformersJsRuntime,
+  type OnnxTextGenerationRuntime
+} from "@independo/inderun-web/onnx";
+import {
+  getDemoModel,
+  getDemoOnnxModelPackageId,
+  getDemoOnnxModelRef,
+  getDemoProxyEndpointUrl
+} from "./config";
+
+const onnxModelRef = getDemoOnnxModelRef();
+
+const onnxModelPackage: ModelPackage = {
+  id: getDemoOnnxModelPackageId(),
+  format: "onnx",
+  tasks: ["text_to_text"],
+  runtime: { platforms: ["web"] },
+  ...(onnxModelRef !== undefined
+    ? { source: { sourceType: "registry", ref: onnxModelRef } }
+    : { source: { sourceType: "programmatic" } })
+};
+
+// Without VITE_INDERUN_ONNX_MODEL_ID the on-device route runs against the deterministic fixture
+// runtime, so reviewers can exercise local_required routing offline and without model downloads.
+const onnxRuntime: OnnxTextGenerationRuntime =
+  onnxModelRef !== undefined ? createTransformersJsRuntime() : createFixtureOnnxRuntime();
 
 const inderun = createIndeRunWeb({
   openAI: {
     model: getDemoModel(),
     endpointUrl: getDemoProxyEndpointUrl(),
     auth: "none"
+  },
+  onnx: {
+    modelPackage: onnxModelPackage,
+    runtime: onnxRuntime
   }
 });
 
@@ -23,9 +54,14 @@ export async function runPrompt(
   });
 }
 
-export function getDemoClientConfig(): { model: string; proxyEndpointUrl: string } {
+export function getDemoClientConfig(): {
+  model: string;
+  proxyEndpointUrl: string;
+  onDeviceModel: string;
+} {
   return {
     model: getDemoModel(),
-    proxyEndpointUrl: getDemoProxyEndpointUrl()
+    proxyEndpointUrl: getDemoProxyEndpointUrl(),
+    onDeviceModel: onnxModelRef ?? "deterministic fixture runtime"
   };
 }

--- a/packages/inderun-web-demo/vite.config.ts
+++ b/packages/inderun-web-demo/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  optimizeDeps: {
+    // Transformers.js ships its own ONNX Runtime WASM assets and must not be pre-bundled.
+    exclude: ["@huggingface/transformers"]
+  },
   server: {
+    // Cross-origin isolation lets onnxruntime-web use WASM threads for on-device execution.
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp"
+    },
     proxy: {
       "/api/inderun": {
         target: "http://127.0.0.1:8787",

--- a/packages/inderun-web/README.md
+++ b/packages/inderun-web/README.md
@@ -8,7 +8,7 @@
 
 TypeScript/Web SDK for IndeRun.
 
-This package provides the Web SDK entrypoint, the engine core, routing, telemetry, error normalization, and the OpenAI-compatible cloud provider.
+This package provides the Web SDK entrypoint, the engine core, routing, telemetry, error normalization, the OpenAI-compatible cloud provider, and the Web ONNX Runtime provider for developer-supplied local models.
 
 ## Basic Usage
 
@@ -47,6 +47,122 @@ The provider normalizes OpenAI transport and API failures into the IndeRun error
 taxonomy (`AuthError`, `RateLimited`, `Timeout`, `Unavailable`, `Internal`). The
 exact status-to-class mapping is documented on the provider in code — see
 `OpenAIResponsesProvider` — so it stays in sync with behavior.
+
+## On-Device Models: ONNX Runtime (Web)
+
+`local.onnx.genai.web` runs developer-supplied ONNX models in the browser. Registering it is what
+makes `constraints.privacy = "local_required"` routable. Pass `onnx` to the factory (`openAI` and
+`onnx` are both optional, but at least one is required):
+
+```ts
+import { createIndeRunWeb } from "@independo/inderun-web";
+
+const inderun = createIndeRunWeb({
+  onnx: {
+    modelPackage: {
+      id: "phi-3-mini-web",
+      format: "onnx",
+      tasks: ["text_to_text"],
+      runtime: { platforms: ["web"] },
+      source: { sourceType: "registry", ref: "onnx-community/Phi-3-mini-4k-instruct" }
+    }
+  }
+});
+```
+
+`modelPackage` is the provider-neutral `ModelPackage` contract from
+`@independo/inderun-contracts`; only `id` and `format` are required, and the package is validated
+(including the inline-secret and URL-userinfo rules) before every attempt. Model files must never
+carry credentials — use `authContextRef` and secure storage instead.
+
+Options: `id` (defaults to `local.onnx.genai.web`), `modelPackage` (required), `runtime`, and
+`timeoutMs` (a request's `constraints.timeoutMs` wins).
+
+The default runtime loads **quantized** weights (`q4f16` on WebGPU, `q4` otherwise). Transformers.js
+would otherwise pick `fp32`, which makes ONNX Runtime fail session creation with an allocation error
+(`std::bad_alloc`) for anything but tiny models. Override with `dtype` when your model does not
+publish that variant:
+
+```ts
+import { OnnxRuntimeWebProvider, createTransformersJsRuntime } from "@independo/inderun-web/onnx";
+
+const provider = new OnnxRuntimeWebProvider({
+  modelPackage,
+  runtime: createTransformersJsRuntime({ dtype: "q8", device: "wasm" })
+});
+```
+
+The default runtime targets models that load through the Transformers.js `text-generation` pipeline
+— for example `onnx-community/gemma-3-1b-it-ONNX`. Multimodal exports split across separate
+encoder/decoder graphs need `AutoProcessor` plus a model-specific class and should implement the
+runtime seam instead — see [Custom runtimes](#custom-runtimes).
+
+### Runtime dependency
+
+The default runtime uses [Transformers.js](https://www.npmjs.com/package/@huggingface/transformers),
+which runs ONNX models on `onnxruntime-web` and owns the generation loop (ONNX Runtime GenAI has no
+browser build). It is an optional dependency that IndeRun does not bundle — install it yourself:
+
+```sh
+pnpm add @huggingface/transformers
+```
+
+If the package is present but fails to initialize, the provider reports itself unavailable and
+routing produces an explainable `capability_unavailable` rejection instead of throwing. Bundlers do
+need to resolve the specifier, so an app that imports `@independo/inderun-web/onnx` without
+installing Transformers.js should pass its own runtime (or a `load` override) — see
+[Custom runtimes](#custom-runtimes). WASM threads additionally require
+cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin`,
+`Cross-Origin-Embedder-Policy: require-corp`) on whatever serves your app.
+
+### Supported model sources
+
+| `source.sourceType` | Web         |
+| ------------------- | ----------- |
+| `registry`          | Supported (hub model id in `source.ref`) |
+| `bundled`           | Supported (assets served by your app) |
+| `app_managed`       | Supported (assets served by your app) |
+| `programmatic`      | Supported (requires `createGenerator`) |
+| `remote`            | Deferred — download yourself, then declare the files |
+| `filesystem`        | Unsupported — browsers cannot read arbitrary local paths |
+
+### Errors
+
+| Condition                                                   | `errorClass`         |
+| ----------------------------------------------------------- | -------------------- |
+| Capability gate fails pre-attempt, model missing/incompatible | `CapabilityMismatch` |
+| Runtime initialization failure, resource exhaustion          | `Unavailable`        |
+| Generation exceeded its timeout budget                       | `Timeout`            |
+| Malformed/empty model output, unexpected runtime failure     | `Internal`           |
+
+A purely local runtime never produces `AuthError`, `RateLimited`, or `Offline`.
+
+### Custom runtimes
+
+Swap the execution backend without touching provider semantics by implementing
+`OnnxTextGenerationRuntime`:
+
+```ts
+import {
+  OnnxRuntimeWebProvider,
+  OnnxRuntimeError,
+  createFixtureOnnxRuntime,
+  type OnnxTextGenerationRuntime
+} from "@independo/inderun-web/onnx";
+
+const runtime: OnnxTextGenerationRuntime = {
+  async prepare(modelPackage) {
+    return { available: true };
+  },
+  async generate({ messages, generation }, signal) {
+    // Throw OnnxRuntimeError("capability" | "unavailable" | "timeout" | "internal", …)
+    // to steer IndeRun error normalization.
+    return { text: "…" };
+  }
+};
+```
+
+`createFixtureOnnxRuntime()` provides a deterministic in-memory runtime for tests and offline demos.
 
 ## Commands
 

--- a/packages/inderun-web/package.json
+++ b/packages/inderun-web/package.json
@@ -40,6 +40,10 @@
     "./openai": {
       "types": "./dist/openai.d.ts",
       "default": "./dist/openai.js"
+    },
+    "./onnx": {
+      "types": "./dist/onnx.d.ts",
+      "default": "./dist/onnx.js"
     }
   },
   "files": [
@@ -54,6 +58,14 @@
   "dependencies": {
     "@independo/inderun-contracts": "workspace:^",
     "@independo/inderun-route-core-wasm": "workspace:^"
+  },
+  "peerDependencies": {
+    "@huggingface/transformers": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/inderun-web/src/engine.test.ts
+++ b/packages/inderun-web/src/engine.test.ts
@@ -370,6 +370,32 @@ describe("IndeRun Engine Core Skeleton Tests", () => {
       expect(result.telemetry.totalMs).toBe(100);
     });
 
+    it("honors an explicit privacy descriptor when routing local_required through the fallback planner", async () => {
+      // Regression: the fallback planner used to read `dataLeavesDevice` without negating it,
+      // which rejected local providers that declare their privacy explicitly and admitted cloud
+      // ones. Mirrors `is_data_private` in the shared Rust planner.
+      const localProvider = createMockLocalProvider("mock-local-private", true);
+      const localDescriptor = localProvider.describe();
+      localProvider.describe = () => ({
+        ...localDescriptor,
+        privacy: { dataLeavesDevice: false }
+      });
+
+      registry.register(createMockCloudProvider("mock-cloud-1", true));
+      registry.register(localProvider);
+
+      const engine = new IndeRun(registry, createMockHostServices(true));
+
+      const result = await engine.run({
+        schemaVersion: "1.0",
+        task: { kind: "text_to_text" },
+        prompt: "test prompt",
+        constraints: { privacy: "local_required" }
+      });
+
+      expect(result.telemetry.providerUsed).toBe("mock-local-private");
+    });
+
     it("ensures the result runId matches the engine's runId", async () => {
       const provider = createMockLocalProvider("mock-local-1", true);
       registry.register(provider);

--- a/packages/inderun-web/src/onnx-provider.test.ts
+++ b/packages/inderun-web/src/onnx-provider.test.ts
@@ -1,0 +1,421 @@
+import type { ModelPackage, TaskRequest } from "@independo/inderun-contracts";
+import { describe, expect, it } from "vitest";
+import {
+  IndeRun,
+  IndeRunException,
+  ProviderRegistry,
+  type HostServices,
+  type ProviderAdapter
+} from "./index.js";
+import {
+  DEFAULT_ONNX_WEB_PROVIDER_ID,
+  OnnxRuntimeError,
+  OnnxRuntimeWebProvider,
+  createFixtureOnnxRuntime,
+  type OnnxProviderOptions,
+  type OnnxTextGenerationRuntime
+} from "./onnx.js";
+
+const MODEL_PACKAGE: ModelPackage = {
+  id: "phi-3-mini-web",
+  format: "onnx",
+  tasks: ["text_to_text"],
+  runtime: { platforms: ["web"] },
+  source: { sourceType: "registry", ref: "onnx-community/Phi-3-mini" }
+};
+
+function modelPackage(overrides: Partial<ModelPackage> = {}): ModelPackage {
+  return { ...MODEL_PACKAGE, ...overrides } as ModelPackage;
+}
+
+function createHost(): HostServices {
+  return {
+    connectivity: {
+      async isOnline() {
+        return true;
+      }
+    },
+    clock: {
+      now() {
+        return 1000;
+      }
+    }
+  };
+}
+
+function createProvider(overrides: Partial<OnnxProviderOptions> = {}): OnnxRuntimeWebProvider {
+  return new OnnxRuntimeWebProvider({
+    modelPackage: MODEL_PACKAGE,
+    runtime: createFixtureOnnxRuntime(),
+    ...overrides
+  });
+}
+
+function createRequest(overrides: Partial<TaskRequest> = {}): TaskRequest {
+  const request: TaskRequest = {
+    schemaVersion: "1.0",
+    task: { kind: "text_to_text" },
+    prompt: "Say hello.",
+    constraints: { privacy: "local_required" }
+  };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete (request as Record<string, unknown>)[key];
+    } else {
+      (request as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return request;
+}
+
+async function runWithProviders(request: TaskRequest, ...providers: ProviderAdapter[]) {
+  const registry = new ProviderRegistry();
+  for (const provider of providers) {
+    registry.register(provider);
+  }
+
+  const engine = new IndeRun(registry, createHost());
+  return engine.run(request);
+}
+
+/** Minimal cloud adapter used to prove strict-local policy never falls back to cloud. */
+function createCloudProvider(): ProviderAdapter {
+  return {
+    describe: () => ({
+      id: "cloud-test",
+      type: "cloud",
+      transport: "http",
+      supports: {
+        run: true,
+        streaming: false,
+        realtime: false,
+        tools: false,
+        reasoningEvents: false,
+        structuredOutput: false,
+        multimodal: false
+      },
+      cancel: "hard",
+      tasks: ["text_to_text"],
+      privacy: { dataLeavesDevice: true }
+    }),
+    capabilities: async () => ({ available: true }),
+    run: async (_request, context) => ({
+      schemaVersion: "1.0",
+      runId: context.runId,
+      output: { type: "text", text: "cloud output" },
+      finishReason: "stop",
+      telemetry: { providerUsed: "cloud-test", totalMs: 0 }
+    })
+  };
+}
+
+describe("OnnxRuntimeWebProvider descriptor", () => {
+  it("describes a local, run-only, soft-cancel provider that keeps data on device", () => {
+    const descriptor = createProvider().describe();
+
+    expect(descriptor).toEqual({
+      id: DEFAULT_ONNX_WEB_PROVIDER_ID,
+      type: "local",
+      transport: "in_process",
+      supports: {
+        run: true,
+        streaming: false,
+        realtime: false,
+        tools: false,
+        reasoningEvents: false,
+        structuredOutput: false,
+        multimodal: false
+      },
+      cancel: "soft",
+      tasks: ["text_to_text"],
+      privacy: { dataLeavesDevice: false }
+    });
+  });
+
+  it("uses the model package tasks and an explicit provider id override", () => {
+    const provider = createProvider({
+      id: "custom.onnx",
+      modelPackage: modelPackage({ tasks: ["text_to_text", "embeddings"] })
+    });
+
+    expect(provider.describe().id).toBe("custom.onnx");
+    expect(provider.describe().tasks).toEqual(["text_to_text", "embeddings"]);
+  });
+});
+
+describe("OnnxRuntimeWebProvider capabilities", () => {
+  it("is available when the model package and runtime are usable", async () => {
+    await expect(createProvider().capabilities(createHost())).resolves.toEqual({
+      available: true
+    });
+  });
+
+  it("rejects a malformed model package", async () => {
+    const provider = createProvider({
+      modelPackage: { format: "onnx" } as unknown as ModelPackage
+    });
+
+    const capabilities = await provider.capabilities(createHost());
+
+    expect(capabilities.available).toBe(false);
+    expect(capabilities.reason).toContain("model package malformed");
+  });
+
+  it("rejects filesystem model sources as unsupported on Web", async () => {
+    const provider = createProvider({
+      modelPackage: modelPackage({ source: { sourceType: "filesystem", ref: "/models/phi3" } })
+    });
+
+    const capabilities = await provider.capabilities(createHost());
+
+    expect(capabilities.available).toBe(false);
+    expect(capabilities.reason).toContain("'filesystem' model sources are unsupported on Web");
+  });
+
+  it("rejects remote model sources as deferred on Web", async () => {
+    const provider = createProvider({
+      modelPackage: modelPackage({
+        source: { sourceType: "remote", ref: "https://models.example/phi3" }
+      })
+    });
+
+    const capabilities = await provider.capabilities(createHost());
+
+    expect(capabilities.available).toBe(false);
+    expect(capabilities.reason).toContain("'remote' model sources are deferred on Web");
+  });
+
+  it("accepts every Web-supported model source type", async () => {
+    for (const sourceType of ["registry", "bundled", "programmatic", "app_managed"] as const) {
+      const provider = createProvider({
+        modelPackage: modelPackage({ source: { sourceType, ref: "models/phi3" } })
+      });
+
+      await expect(provider.capabilities(createHost())).resolves.toEqual({ available: true });
+    }
+  });
+
+  it("rejects a model package that does not target the web platform", async () => {
+    const provider = createProvider({
+      modelPackage: modelPackage({ runtime: { platforms: ["android", "apple"] } })
+    });
+
+    const capabilities = await provider.capabilities(createHost());
+
+    expect(capabilities.available).toBe(false);
+    expect(capabilities.reason).toContain("platform unsupported");
+  });
+
+  it("rejects a model package that does not declare text_to_text", async () => {
+    const provider = createProvider({ modelPackage: modelPackage({ tasks: ["embeddings"] }) });
+
+    const capabilities = await provider.capabilities(createHost());
+
+    expect(capabilities.available).toBe(false);
+    expect(capabilities.reason).toContain("unsupported task");
+  });
+
+  it("surfaces the runtime availability reason unchanged", async () => {
+    const provider = createProvider({
+      runtime: createFixtureOnnxRuntime({
+        availability: { available: false, reason: "execution backend unavailable: no WebGPU." }
+      })
+    });
+
+    await expect(provider.capabilities(createHost())).resolves.toEqual({
+      available: false,
+      reason: "execution backend unavailable: no WebGPU."
+    });
+  });
+});
+
+describe("OnnxRuntimeWebProvider run", () => {
+  it("executes a local run and reports the provider in telemetry", async () => {
+    const result = await runWithProviders(createRequest(), createProvider());
+
+    expect(result.output.text).toBe("[fixture:phi-3-mini-web] Say hello.");
+    expect(result.finishReason).toBe("stop");
+    expect(result.telemetry.providerUsed).toBe(DEFAULT_ONNX_WEB_PROVIDER_ID);
+  });
+
+  it("is selected over a cloud provider under local_required policy", async () => {
+    const result = await runWithProviders(createRequest(), createCloudProvider(), createProvider());
+
+    expect(result.telemetry.providerUsed).toBe(DEFAULT_ONNX_WEB_PROVIDER_ID);
+  });
+
+  it("does not fall back to cloud when the local provider is unavailable under local_required", async () => {
+    const provider = createProvider({
+      runtime: createFixtureOnnxRuntime({
+        availability: { available: false, reason: "model files missing." }
+      })
+    });
+
+    await expect(
+      runWithProviders(createRequest(), createCloudProvider(), provider)
+    ).rejects.toMatchObject({ errorClass: "CapabilityMismatch" });
+  });
+
+  it("never retries on a cloud provider when the local attempt fails under local_required", async () => {
+    // Regression: the fallback planner filtered only the selected provider by constraints, so a
+    // failing local_required attempt was retried against the cloud fallback.
+    const provider = createProvider({
+      runtime: createFixtureOnnxRuntime({
+        failWith: new OnnxRuntimeError("internal", "generation blew up")
+      })
+    });
+
+    const error = (await runWithProviders(createRequest(), createCloudProvider(), provider).catch(
+      (err: unknown) => err
+    )) as IndeRunException;
+
+    expect(error.errorClass).toBe("Internal");
+    expect(error.message).toBe("generation blew up");
+    expect(error.details?.attemptedProviderIds).toEqual([DEFAULT_ONNX_WEB_PROVIDER_ID]);
+  });
+
+  it("normalizes the last user message when messages are supplied", async () => {
+    const seen: string[] = [];
+    const runtime: OnnxTextGenerationRuntime = {
+      async prepare() {
+        return { available: true };
+      },
+      async generate(input) {
+        seen.push(...input.messages.map((message) => `${message.role}:${message.content}`));
+        return { text: "ok" };
+      }
+    };
+
+    await runWithProviders(
+      createRequest({
+        prompt: undefined,
+        messages: [
+          { role: "system", content: "Be terse." },
+          { role: "user", content: "Hi." }
+        ]
+      }),
+      createProvider({ runtime })
+    );
+
+    expect(seen).toEqual(["system:Be terse.", "user:Hi."]);
+  });
+
+  it("passes generation controls through to the runtime", async () => {
+    let received: unknown;
+    const runtime: OnnxTextGenerationRuntime = {
+      async prepare() {
+        return { available: true };
+      },
+      async generate(input) {
+        received = input.generation;
+        return { text: "ok" };
+      }
+    };
+
+    await runWithProviders(
+      createRequest({ generation: { maxOutputTokens: 32, temperature: 0.2 } }),
+      createProvider({ runtime })
+    );
+
+    expect(received).toEqual({ maxOutputTokens: 32, temperature: 0.2 });
+  });
+
+  it("returns runtime-reported finish reason and usage", async () => {
+    const runtime: OnnxTextGenerationRuntime = {
+      async prepare() {
+        return { available: true };
+      },
+      async generate() {
+        return {
+          text: "truncated",
+          finishReason: "length" as const,
+          usage: { inputTokens: 4, outputTokens: 8 }
+        };
+      }
+    };
+
+    const result = await runWithProviders(createRequest(), createProvider({ runtime }));
+
+    expect(result.finishReason).toBe("length");
+    expect(result.usage).toEqual({ inputTokens: 4, outputTokens: 8 });
+  });
+
+  it("rejects a request without prompt or messages as Internal", async () => {
+    await expect(
+      runWithProviders(createRequest({ prompt: undefined }), createProvider())
+    ).rejects.toMatchObject({ errorClass: "Internal" });
+  });
+
+  it("maps an empty model output to Internal", async () => {
+    const provider = createProvider({
+      runtime: createFixtureOnnxRuntime({ respond: () => "" })
+    });
+
+    await expect(runWithProviders(createRequest(), provider)).rejects.toMatchObject({
+      errorClass: "Internal"
+    });
+  });
+});
+
+describe("OnnxRuntimeWebProvider error mapping", () => {
+  const cases: Array<[OnnxRuntimeError["kind"], string]> = [
+    ["capability", "CapabilityMismatch"],
+    ["unavailable", "Unavailable"],
+    ["timeout", "Timeout"],
+    ["internal", "Internal"]
+  ];
+
+  for (const [kind, errorClass] of cases) {
+    it(`maps runtime error kind '${kind}' to ${errorClass}`, async () => {
+      const provider = createProvider({
+        runtime: createFixtureOnnxRuntime({
+          failWith: new OnnxRuntimeError(kind, `${kind} failure`)
+        })
+      });
+
+      await expect(runWithProviders(createRequest(), provider)).rejects.toMatchObject({
+        errorClass,
+        message: `${kind} failure`,
+        providerId: DEFAULT_ONNX_WEB_PROVIDER_ID
+      });
+    });
+  }
+
+  it("maps an unexpected runtime throwable to Internal", async () => {
+    const provider = createProvider({
+      runtime: createFixtureOnnxRuntime({ failWith: new Error("boom") })
+    });
+
+    const error = await runWithProviders(createRequest(), provider).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(IndeRunException);
+    expect((error as IndeRunException).errorClass).toBe("Internal");
+  });
+
+  it("maps a generation timeout to Timeout", async () => {
+    const provider = createProvider({
+      timeoutMs: 5,
+      runtime: createFixtureOnnxRuntime({ delayMs: 50 })
+    });
+
+    await expect(runWithProviders(createRequest(), provider)).rejects.toMatchObject({
+      errorClass: "Timeout"
+    });
+  });
+
+  it("never produces cloud-only error classes for a local runtime", async () => {
+    const provider = createProvider({
+      runtime: createFixtureOnnxRuntime({
+        failWith: new OnnxRuntimeError("unavailable", "runtime initialization failed")
+      })
+    });
+
+    const error = (await runWithProviders(createRequest(), provider).catch(
+      (err: unknown) => err
+    )) as IndeRunException;
+
+    expect(["AuthError", "RateLimited", "Offline"]).not.toContain(error.errorClass);
+  });
+});

--- a/packages/inderun-web/src/onnx-provider.ts
+++ b/packages/inderun-web/src/onnx-provider.ts
@@ -1,0 +1,300 @@
+import {
+  getModelPackageValidationIssues,
+  type ModelPackage,
+  type ModelSourceType,
+  type TaskRequest,
+  type TaskResult
+} from "@independo/inderun-contracts";
+import {
+  createCapabilityMismatch,
+  createInternal,
+  createTimeout,
+  createUnavailable,
+  toIndeRunException,
+  type IndeRunException
+} from "./errors.js";
+import type { HostServices } from "./host.js";
+import {
+  OnnxRuntimeError,
+  type OnnxGenerationMessage,
+  type OnnxGenerationOutput,
+  type OnnxTextGenerationRuntime
+} from "./onnx-runtime.js";
+import { createTransformersJsRuntime } from "./onnx-transformers-runtime.js";
+import type {
+  ProviderAdapter,
+  ProviderDescriptor,
+  ProviderDynamicCapabilities,
+  RunContext
+} from "./provider.js";
+
+/** Default provider id of the Web member of the ONNX Runtime provider family. */
+export const DEFAULT_ONNX_WEB_PROVIDER_ID = "local.onnx.genai.web";
+
+/** Task kind this provider implements in Milestone 2 (Mode 1 only). */
+const TEXT_TO_TEXT = "text_to_text";
+
+/**
+ * Model source types the Web member of the ONNX Runtime provider family can honor.
+ *
+ * `filesystem` is unsupported because browsers do not expose arbitrary local paths, and `remote`
+ * is deferred: hosts download model files themselves and then supply them as `bundled`,
+ * `app_managed`, or `programmatic`.
+ */
+export const SUPPORTED_WEB_MODEL_SOURCE_TYPES: readonly ModelSourceType[] = [
+  "registry",
+  "bundled",
+  "programmatic",
+  "app_managed"
+];
+
+/**
+ * Configuration for the Web ONNX Runtime provider.
+ */
+export interface OnnxProviderOptions {
+  /**
+   * Provider id exposed in telemetry and routing explanations.
+   */
+  id?: string;
+  /**
+   * Provider-neutral bootstrap metadata describing the developer-supplied model.
+   */
+  modelPackage: ModelPackage;
+  /**
+   * Runtime implementation used to execute generation. Defaults to the Transformers.js-backed
+   * runtime; applications can inject their own implementation of the seam.
+   */
+  runtime?: OnnxTextGenerationRuntime;
+  /**
+   * Optional generation timeout in milliseconds. A request-level `constraints.timeoutMs` wins.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Local provider adapter that executes Mode-1 text-to-text requests with a developer-supplied ONNX
+ * model in the browser.
+ *
+ * The adapter owns the IndeRun-facing contract (descriptor, capability checks, error taxonomy) and
+ * delegates execution to an injectable {@link OnnxTextGenerationRuntime}. ONNX Runtime execution
+ * backends (WASM, WebGPU, WebNN) stay behind that seam and are never public routing concepts.
+ */
+export class OnnxRuntimeWebProvider implements ProviderAdapter {
+  private readonly id: string;
+  private readonly modelPackage: ModelPackage;
+  private readonly runtime: OnnxTextGenerationRuntime;
+
+  /**
+   * Creates a Web ONNX Runtime provider.
+   * @param options - Model package plus optional id, runtime, and timeout overrides.
+   */
+  constructor(private readonly options: OnnxProviderOptions) {
+    this.id = options.id ?? DEFAULT_ONNX_WEB_PROVIDER_ID;
+    this.modelPackage = options.modelPackage;
+    this.runtime = options.runtime ?? createTransformersJsRuntime();
+  }
+
+  /**
+   * Returns static metadata used by the router for deterministic provider selection.
+   */
+  describe(): ProviderDescriptor {
+    return {
+      id: this.id,
+      type: "local",
+      transport: "in_process",
+      supports: {
+        run: true,
+        streaming: false,
+        realtime: false,
+        tools: false,
+        reasoningEvents: false,
+        structuredOutput: false,
+        multimodal: false
+      },
+      cancel: "soft",
+      tasks: getDeclaredTasks(this.modelPackage),
+      privacy: {
+        dataLeavesDevice: false
+      }
+    };
+  }
+
+  /**
+   * Reports dynamic provider availability for the current host.
+   *
+   * Every failure below is provider-internal detail: the shared route planner flattens it into a
+   * single `capability_unavailable` rejection carrying the returned reason.
+   *
+   * @param _host - Host services available to the engine (unused; ONNX runs in-process).
+   */
+  async capabilities(_host: HostServices): Promise<ProviderDynamicCapabilities> {
+    const issues = getModelPackageValidationIssues(this.modelPackage);
+    if (issues.length > 0) {
+      const summary = issues.map((issue) => `${issue.path} ${issue.message}`).join("; ");
+      return { available: false, reason: `model package malformed: ${summary}` };
+    }
+
+    const sourceType = this.modelPackage.source?.sourceType;
+    if (sourceType !== undefined && !SUPPORTED_WEB_MODEL_SOURCE_TYPES.includes(sourceType)) {
+      return {
+        available: false,
+        reason:
+          sourceType === "filesystem"
+            ? "model source unavailable: 'filesystem' model sources are unsupported on Web because browsers cannot read arbitrary local paths."
+            : `model source unavailable: '${sourceType}' model sources are deferred on Web; supply model files as ${SUPPORTED_WEB_MODEL_SOURCE_TYPES.join(", ")}.`
+      };
+    }
+
+    const platforms = this.modelPackage.runtime?.platforms;
+    if (Array.isArray(platforms) && platforms.length > 0 && !platforms.includes("web")) {
+      return {
+        available: false,
+        reason: `platform unsupported: the model package targets ${platforms.join(", ")} and does not list 'web'.`
+      };
+    }
+
+    if (!getDeclaredTasks(this.modelPackage).includes(TEXT_TO_TEXT)) {
+      return {
+        available: false,
+        reason: `unsupported task: the model package declares ${getDeclaredTasks(this.modelPackage).join(", ")} and does not support '${TEXT_TO_TEXT}'.`
+      };
+    }
+
+    return this.runtime.prepare(this.modelPackage);
+  }
+
+  /**
+   * Executes a normalized text-to-text task on the developer-supplied local ONNX model.
+   * @param request - Canonical IndeRun task request.
+   * @param context - Engine execution context containing run id and host services.
+   * @returns Normalized IndeRun task result.
+   * @throws IndeRunException mapped to the standard error taxonomy.
+   */
+  async run(request: TaskRequest, context: RunContext): Promise<TaskResult> {
+    const availability = await this.capabilities(context.hostServices);
+    if (!availability.available) {
+      throw createCapabilityMismatch(
+        availability.reason ?? "ONNX Runtime Web provider is unavailable on this host.",
+        { providerId: this.id, runId: context.runId }
+      );
+    }
+
+    const messages = createMessages(request);
+    if (messages.length === 0) {
+      throw createInternal("ONNX Runtime Web provider requires a prompt or messages.", {
+        providerId: this.id,
+        runId: context.runId
+      });
+    }
+
+    const timeoutMs = request.constraints?.timeoutMs ?? this.options.timeoutMs;
+    const controller = new AbortController();
+    const timer =
+      timeoutMs !== undefined && timeoutMs > 0
+        ? setTimeout(() => controller.abort(), timeoutMs)
+        : undefined;
+
+    let output: OnnxGenerationOutput;
+    try {
+      output = await this.runtime.generate(
+        {
+          modelPackage: this.modelPackage,
+          messages,
+          ...(request.generation !== undefined ? { generation: request.generation } : {})
+        },
+        controller.signal
+      );
+    } catch (err) {
+      throw this.mapRuntimeError(err, context);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+
+    if (typeof output.text !== "string" || output.text.length === 0) {
+      throw createInternal("ONNX Runtime Web provider returned no text output.", {
+        providerId: this.id,
+        runId: context.runId
+      });
+    }
+
+    const result: TaskResult = {
+      schemaVersion: "1.0",
+      runId: context.runId,
+      output: {
+        type: "text",
+        text: output.text
+      },
+      finishReason: output.finishReason ?? "stop",
+      telemetry: {
+        providerUsed: this.id,
+        totalMs: 0
+      }
+    };
+
+    if (output.usage) {
+      result.usage = output.usage;
+    }
+
+    return result;
+  }
+
+  private mapRuntimeError(error: unknown, context: RunContext): IndeRunException {
+    const extra = { providerId: this.id, runId: context.runId };
+
+    if (error instanceof OnnxRuntimeError) {
+      const details =
+        error.originalError !== undefined
+          ? { details: { originalError: getErrorSummary(error.originalError) } }
+          : {};
+
+      switch (error.kind) {
+        case "capability":
+          return createCapabilityMismatch(error.message, { ...extra, ...details });
+        case "unavailable":
+          return createUnavailable(error.message, { ...extra, ...details });
+        case "timeout":
+          return createTimeout(error.message, { ...extra, ...details });
+        default:
+          return createInternal(error.message, { ...extra, ...details });
+      }
+    }
+
+    if (isAbortError(error)) {
+      return createTimeout("ONNX Runtime Web generation timed out.", extra);
+    }
+
+    return toIndeRunException(error, extra);
+  }
+}
+
+function getDeclaredTasks(modelPackage: ModelPackage): string[] {
+  const tasks = modelPackage.tasks;
+  return Array.isArray(tasks) && tasks.length > 0 ? tasks : [TEXT_TO_TEXT];
+}
+
+function createMessages(request: TaskRequest): OnnxGenerationMessage[] {
+  if (request.messages && request.messages.length > 0) {
+    return request.messages.map((message) => ({
+      role: message.role,
+      content: message.content
+    }));
+  }
+
+  const prompt = request.prompt;
+  return prompt !== undefined && prompt.length > 0 ? [{ role: "user", content: prompt }] : [];
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
+
+function getErrorSummary(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  return { message: String(error) };
+}

--- a/packages/inderun-web/src/onnx-runtime.ts
+++ b/packages/inderun-web/src/onnx-runtime.ts
@@ -1,0 +1,188 @@
+import type { ModelPackage, TaskRequest, TaskResult } from "@independo/inderun-contracts";
+
+/**
+ * Availability snapshot reported by an ONNX text generation runtime.
+ *
+ * The `reason` string uses the provider-internal capability vocabulary documented in
+ * `docs/architecture/onnx-runtime-provider-family.md`. It is not a public enum: the provider
+ * flattens every failure into a single `capability_unavailable` route rejection and carries the
+ * reason as human-readable text.
+ */
+export interface OnnxRuntimeAvailability {
+  /** Whether the runtime can execute the given model package on this host right now. */
+  available: boolean;
+  /** Human-readable detail describing why the runtime is unavailable. */
+  reason?: string;
+}
+
+/**
+ * Normalized conversation turn handed to an ONNX text generation runtime.
+ */
+export interface OnnxGenerationMessage {
+  /** The role of the author of this turn. */
+  role: "system" | "user" | "assistant";
+  /** Plain-text content of this turn. */
+  content: string;
+}
+
+/**
+ * Normalized generation request handed to an ONNX text generation runtime.
+ */
+export interface OnnxGenerationInput {
+  /** The model package the provider was configured with. */
+  modelPackage: ModelPackage;
+  /** Conversation turns, normalized from `prompt` or `messages` by the provider. */
+  messages: OnnxGenerationMessage[];
+  /** Optional generation controls copied from the task request. */
+  generation?: NonNullable<TaskRequest["generation"]>;
+}
+
+/**
+ * Normalized generation result returned by an ONNX text generation runtime.
+ */
+export interface OnnxGenerationOutput {
+  /** The generated text. */
+  text: string;
+  /** Optional normalized finish reason; the provider defaults to `stop`. */
+  finishReason?: TaskResult["finishReason"];
+  /** Optional token accounting, when the runtime reports it. */
+  usage?: TaskResult["usage"];
+}
+
+/**
+ * Failure category a runtime can signal so the provider maps it onto the IndeRun error taxonomy.
+ *
+ * - `capability`: model or runtime cannot serve this request (`CapabilityMismatch`).
+ * - `unavailable`: runtime initialization failure or resource exhaustion (`Unavailable`).
+ * - `timeout`: generation exceeded its budget or was aborted (`Timeout`).
+ * - `internal`: unexpected runtime failure (`Internal`).
+ */
+export type OnnxRuntimeErrorKind = "capability" | "unavailable" | "timeout" | "internal";
+
+/**
+ * Error type ONNX runtime implementations throw to steer IndeRun error normalization.
+ *
+ * Anything else thrown by a runtime is normalized to `Internal`.
+ */
+export class OnnxRuntimeError extends Error {
+  /** Failure category used by the provider to select an IndeRun error class. */
+  readonly kind: OnnxRuntimeErrorKind;
+  /** Optional underlying error captured for telemetry details. */
+  readonly originalError?: unknown;
+
+  constructor(kind: OnnxRuntimeErrorKind, message: string, originalError?: unknown) {
+    super(message);
+    this.name = "OnnxRuntimeError";
+    this.kind = kind;
+    if (originalError !== undefined) this.originalError = originalError;
+
+    Object.setPrototypeOf(this, OnnxRuntimeError.prototype);
+  }
+}
+
+/**
+ * Injectable seam between the IndeRun ONNX Web provider and the actual on-device runtime.
+ *
+ * IndeRun ships a Transformers.js-backed implementation as the default and a deterministic
+ * fixture for tests, but applications can supply their own implementation (for example a
+ * hand-rolled `onnxruntime-web` pipeline) without touching the provider.
+ */
+export interface OnnxTextGenerationRuntime {
+  /**
+   * Checks runtime package availability, execution backend availability, and model readiness.
+   * Implementations must resolve with an availability snapshot rather than throwing.
+   */
+  prepare(modelPackage: ModelPackage): Promise<OnnxRuntimeAvailability>;
+  /**
+   * Runs one Mode-1 generation. Implementations should honor `signal` where the underlying
+   * runtime allows it; ONNX inference is not hard-interruptible, so cancellation is best effort.
+   */
+  generate(input: OnnxGenerationInput, signal?: AbortSignal): Promise<OnnxGenerationOutput>;
+}
+
+/**
+ * Configuration for the deterministic fixture runtime.
+ */
+export interface FixtureOnnxRuntimeOptions {
+  /** Availability snapshot returned by `prepare`. Defaults to `{ available: true }`. */
+  availability?: OnnxRuntimeAvailability;
+  /** Text or full output produced by `generate`. Defaults to a deterministic echo. */
+  respond?: (input: OnnxGenerationInput) => string | OnnxGenerationOutput;
+  /** Error thrown by `generate` instead of producing output. */
+  failWith?: unknown;
+  /** Artificial generation delay in milliseconds, used to exercise timeouts. */
+  delayMs?: number;
+}
+
+/**
+ * Creates a deterministic in-memory ONNX runtime.
+ *
+ * This is the test seam mandated by the ONNX Runtime provider family specification: it proves the
+ * model package contract, capability checks, routing, and error normalization without depending on
+ * a real ONNX runtime, and it lets demos exercise the on-device route offline.
+ *
+ * @param options - Scripted availability, response, failure, and delay behavior.
+ */
+export function createFixtureOnnxRuntime(
+  options: FixtureOnnxRuntimeOptions = {}
+): OnnxTextGenerationRuntime {
+  const availability = options.availability ?? { available: true };
+
+  return {
+    async prepare(): Promise<OnnxRuntimeAvailability> {
+      return availability;
+    },
+    async generate(
+      input: OnnxGenerationInput,
+      signal?: AbortSignal
+    ): Promise<OnnxGenerationOutput> {
+      if (options.delayMs !== undefined && options.delayMs > 0) {
+        await delay(options.delayMs, signal);
+      }
+
+      throwIfAborted(signal);
+
+      if (options.failWith !== undefined) {
+        throw options.failWith;
+      }
+
+      const response = options.respond
+        ? options.respond(input)
+        : createFixtureText(input.modelPackage, input.messages);
+
+      return typeof response === "string" ? { text: response } : response;
+    }
+  };
+}
+
+function createFixtureText(modelPackage: ModelPackage, messages: OnnxGenerationMessage[]): string {
+  const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
+  const prompt = lastUserMessage?.content ?? "";
+  return `[fixture:${modelPackage.id}] ${prompt}`;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    function onAbort(): void {
+      clearTimeout(timer);
+      reject(new OnnxRuntimeError("timeout", "Fixture ONNX generation was aborted."));
+    }
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new OnnxRuntimeError("timeout", "Fixture ONNX generation was aborted.");
+  }
+}

--- a/packages/inderun-web/src/onnx-transformers-runtime.test.ts
+++ b/packages/inderun-web/src/onnx-transformers-runtime.test.ts
@@ -1,0 +1,315 @@
+import type { ModelPackage } from "@independo/inderun-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { OnnxRuntimeError } from "./onnx-runtime.js";
+import {
+  createTransformersJsRuntime,
+  type TransformersModule,
+  type TransformersTextGenerator
+} from "./onnx-transformers-runtime.js";
+
+interface PipelineCall {
+  task: string;
+  model?: string;
+  options?: Record<string, unknown>;
+}
+
+interface GenerateCall {
+  input: unknown;
+  options?: Record<string, unknown>;
+}
+
+function createFakeModule(
+  generator: TransformersTextGenerator = async () => [
+    { generated_text: [{ role: "assistant", content: "hello from onnx" }] }
+  ]
+): { module: TransformersModule; pipelineCalls: PipelineCall[]; generateCalls: GenerateCall[] } {
+  const pipelineCalls: PipelineCall[] = [];
+  const generateCalls: GenerateCall[] = [];
+
+  const module: TransformersModule = {
+    env: {},
+    async pipeline(task, model, options) {
+      pipelineCalls.push({
+        task,
+        ...(model !== undefined ? { model } : {}),
+        ...(options !== undefined ? { options } : {})
+      });
+      return async (input, generateOptions) => {
+        generateCalls.push({
+          input,
+          ...(generateOptions !== undefined ? { options: generateOptions } : {})
+        });
+        return generator(input, generateOptions);
+      };
+    }
+  };
+
+  return { module, pipelineCalls, generateCalls };
+}
+
+function modelPackage(overrides: Partial<ModelPackage> = {}): ModelPackage {
+  return {
+    id: "phi-3-mini-web",
+    format: "onnx",
+    tasks: ["text_to_text"],
+    source: { sourceType: "registry", ref: "onnx-community/Phi-3-mini" },
+    ...overrides
+  } as ModelPackage;
+}
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+function setNavigator(value: unknown): void {
+  Object.defineProperty(globalThis, "navigator", {
+    value,
+    configurable: true,
+    writable: true
+  });
+}
+
+afterEach(() => {
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, "navigator", originalNavigator);
+  } else {
+    Reflect.deleteProperty(globalThis, "navigator");
+  }
+});
+
+describe("createTransformersJsRuntime prepare", () => {
+  it("reports unavailable when the optional dependency is missing", async () => {
+    const runtime = createTransformersJsRuntime({
+      load: async () => {
+        throw new Error("Cannot find package '@huggingface/transformers'");
+      }
+    });
+
+    const availability = await runtime.prepare(modelPackage());
+
+    expect(availability.available).toBe(false);
+    expect(availability.reason).toContain("runtime package unavailable");
+  });
+
+  it("reports unavailable for non-ONNX model formats", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const availability = await runtime.prepare(modelPackage({ format: "genai" }));
+
+    expect(availability.available).toBe(false);
+    expect(availability.reason).toContain("unsupported model format");
+  });
+
+  it("reports unavailable when a programmatic source has no createGenerator", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const availability = await runtime.prepare(
+      modelPackage({ source: { sourceType: "programmatic" } })
+    );
+
+    expect(availability.available).toBe(false);
+    expect(availability.reason).toContain("programmatic model packages require a createGenerator");
+  });
+
+  it("reports unavailable when the model package declares no source.ref", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const availability = await runtime.prepare(
+      modelPackage({ source: { sourceType: "registry" } })
+    );
+
+    expect(availability.available).toBe(false);
+    expect(availability.reason).toContain("does not declare source.ref");
+  });
+
+  it("is available for a registry-sourced ONNX package", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    await expect(runtime.prepare(modelPackage())).resolves.toEqual({ available: true });
+  });
+});
+
+describe("createTransformersJsRuntime generate", () => {
+  it("builds the pipeline from the registry model ref and returns the assistant turn", async () => {
+    const { module, pipelineCalls, generateCalls } = createFakeModule();
+    const runtime = createTransformersJsRuntime({ load: async () => module, device: "wasm" });
+
+    const output = await runtime.generate({
+      modelPackage: modelPackage(),
+      messages: [{ role: "user", content: "Hi." }],
+      generation: { maxOutputTokens: 16, temperature: 0.5, topP: 0.9, stop: ["</s>"] }
+    });
+
+    expect(output.text).toBe("hello from onnx");
+    expect(pipelineCalls[0]?.task).toBe("text-generation");
+    expect(pipelineCalls[0]?.model).toBe("onnx-community/Phi-3-mini");
+    expect(pipelineCalls[0]?.options).toMatchObject({ device: "wasm" });
+    expect(generateCalls[0]?.options).toMatchObject({
+      max_new_tokens: 16,
+      temperature: 0.5,
+      do_sample: true,
+      top_p: 0.9,
+      stop_strings: ["</s>"]
+    });
+  });
+
+  it("defaults to a quantized dtype per device instead of fp32", async () => {
+    // Transformers.js would otherwise load full fp32 weights, which fails ONNX session creation
+    // with std::bad_alloc for all but tiny models.
+    const wasm = createFakeModule();
+    await createTransformersJsRuntime({ load: async () => wasm.module, device: "wasm" }).generate({
+      modelPackage: modelPackage(),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+    expect(wasm.pipelineCalls[0]?.options).toMatchObject({ dtype: "q4" });
+
+    const gpu = createFakeModule();
+    await createTransformersJsRuntime({
+      load: async () => gpu.module,
+      device: "webgpu"
+    }).generate({
+      modelPackage: modelPackage(),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+    expect(gpu.pipelineCalls[0]?.options).toMatchObject({ dtype: "q4f16" });
+  });
+
+  it("lets an explicit dtype override the default", async () => {
+    const { module, pipelineCalls } = createFakeModule();
+    await createTransformersJsRuntime({
+      load: async () => module,
+      device: "wasm",
+      dtype: "fp16"
+    }).generate({
+      modelPackage: modelPackage(),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+
+    expect(pipelineCalls[0]?.options).toMatchObject({ dtype: "fp16" });
+  });
+
+  it("maps allocation failures during model load to an unavailable runtime error", async () => {
+    const { module } = createFakeModule();
+    module.pipeline = async () => {
+      throw new Error("Can't create a session. ERROR_CODE: 6, ERROR_MESSAGE: std::bad_alloc");
+    };
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const error = await runtime
+      .generate({ modelPackage: modelPackage(), messages: [{ role: "user", content: "Hi." }] })
+      .catch((err: unknown) => err);
+
+    expect((error as OnnxRuntimeError).kind).toBe("unavailable");
+    expect((error as OnnxRuntimeError).message).toContain("insufficient memory");
+  });
+
+  it("selects webgpu when navigator.gpu exists and wasm otherwise", async () => {
+    setNavigator({ gpu: {} });
+    const withGpu = createFakeModule();
+    await createTransformersJsRuntime({ load: async () => withGpu.module }).generate({
+      modelPackage: modelPackage(),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+    expect(withGpu.pipelineCalls[0]?.options).toMatchObject({ device: "webgpu" });
+
+    setNavigator({});
+    const withoutGpu = createFakeModule();
+    await createTransformersJsRuntime({ load: async () => withoutGpu.module }).generate({
+      modelPackage: modelPackage(),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+    expect(withoutGpu.pipelineCalls[0]?.options).toMatchObject({ device: "wasm" });
+  });
+
+  it("points Transformers.js at local assets for bundled sources", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({
+      load: async () => module,
+      localModelPath: "/models/"
+    });
+
+    await runtime.generate({
+      modelPackage: modelPackage({ source: { sourceType: "bundled", ref: "phi3-mini" } }),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+
+    expect(module.env).toEqual({
+      allowLocalModels: true,
+      allowRemoteModels: false,
+      localModelPath: "/models/"
+    });
+  });
+
+  it("uses an application-supplied generator for programmatic sources", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({
+      load: async () => module,
+      createGenerator: async () => async () => [{ generated_text: "app supplied" }]
+    });
+
+    const output = await runtime.generate({
+      modelPackage: modelPackage({ source: { sourceType: "programmatic" } }),
+      messages: [{ role: "user", content: "Hi." }]
+    });
+
+    expect(output.text).toBe("app supplied");
+  });
+
+  it("maps model load failures to a capability runtime error", async () => {
+    const { module } = createFakeModule();
+    module.pipeline = async () => {
+      throw new Error("404 model not found");
+    };
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const error = await runtime
+      .generate({ modelPackage: modelPackage(), messages: [{ role: "user", content: "Hi." }] })
+      .catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(OnnxRuntimeError);
+    expect((error as OnnxRuntimeError).kind).toBe("capability");
+  });
+
+  it("maps generation failures to an internal runtime error", async () => {
+    const { module } = createFakeModule(async () => {
+      throw new Error("kernel failure");
+    });
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const error = await runtime
+      .generate({ modelPackage: modelPackage(), messages: [{ role: "user", content: "Hi." }] })
+      .catch((err: unknown) => err);
+
+    expect((error as OnnxRuntimeError).kind).toBe("internal");
+  });
+
+  it("maps malformed pipeline output to an internal runtime error", async () => {
+    const { module } = createFakeModule(async () => [{ unexpected: true }]);
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+
+    const error = await runtime
+      .generate({ modelPackage: modelPackage(), messages: [{ role: "user", content: "Hi." }] })
+      .catch((err: unknown) => err);
+
+    expect((error as OnnxRuntimeError).kind).toBe("internal");
+    expect((error as OnnxRuntimeError).message).toContain("model output malformed");
+  });
+
+  it("rejects an already aborted generation as a timeout", async () => {
+    const { module } = createFakeModule();
+    const runtime = createTransformersJsRuntime({ load: async () => module });
+    const controller = new AbortController();
+    controller.abort();
+
+    const error = await runtime
+      .generate(
+        { modelPackage: modelPackage(), messages: [{ role: "user", content: "Hi." }] },
+        controller.signal
+      )
+      .catch((err: unknown) => err);
+
+    expect((error as OnnxRuntimeError).kind).toBe("timeout");
+  });
+});

--- a/packages/inderun-web/src/onnx-transformers-runtime.ts
+++ b/packages/inderun-web/src/onnx-transformers-runtime.ts
@@ -1,0 +1,345 @@
+import type { ModelPackage } from "@independo/inderun-contracts";
+import {
+  OnnxRuntimeError,
+  type OnnxGenerationInput,
+  type OnnxGenerationOutput,
+  type OnnxRuntimeAvailability,
+  type OnnxTextGenerationRuntime
+} from "./onnx-runtime.js";
+
+/**
+ * Structural view of the `@huggingface/transformers` entry points this runtime uses.
+ *
+ * The dependency is optional, so the module is typed structurally instead of imported for types.
+ */
+export interface TransformersModule {
+  /** Builds a task pipeline, downloading or loading model assets as needed. */
+  pipeline: (
+    task: string,
+    model?: string,
+    options?: Record<string, unknown>
+  ) => Promise<TransformersTextGenerator>;
+  /** Global Transformers.js environment used to point the loader at local model assets. */
+  env?: Record<string, unknown>;
+}
+
+/**
+ * Structural view of a Transformers.js `text-generation` pipeline.
+ */
+export type TransformersTextGenerator = (
+  input: unknown,
+  options?: Record<string, unknown>
+) => Promise<unknown>;
+
+/**
+ * Configuration for the Transformers.js-backed ONNX runtime.
+ */
+export interface TransformersJsRuntimeOptions {
+  /**
+   * Overrides how the `@huggingface/transformers` module is loaded. Tests inject a fake module;
+   * production uses a lazy dynamic import so the dependency stays optional.
+   */
+  load?: () => Promise<TransformersModule>;
+  /**
+   * Execution backend passed to Transformers.js. Defaults to `webgpu` when `navigator.gpu`
+   * exists and `wasm` otherwise. This is an ONNX Runtime execution backend, not an IndeRun
+   * routing concept.
+   */
+  device?: string;
+  /**
+   * Weight quantization passed to Transformers.js (for example `q4`, `q4f16`, `q8`, `fp16`,
+   * `fp32`).
+   *
+   * Defaults to a quantized variant (`q4f16` on WebGPU, `q4` otherwise) because Transformers.js
+   * would otherwise load full `fp32` weights, which exhausts browser memory for all but the
+   * smallest models. Set explicitly when the model does not publish the default variant.
+   */
+  dtype?: string;
+  /** Base path or URL for locally served model assets (`bundled` / `app_managed` sources). */
+  localModelPath?: string;
+  /** Extra options merged into the Transformers.js `pipeline()` call. */
+  pipelineOptions?: Record<string, unknown>;
+  /**
+   * Supplies a pre-built generator instead of letting this runtime construct one. Required for
+   * `programmatic` model sources, where the application owns model resolution.
+   */
+  createGenerator?: (context: {
+    modelPackage: ModelPackage;
+    module: TransformersModule;
+    device: string;
+  }) => Promise<TransformersTextGenerator>;
+}
+
+const TEXT_GENERATION_TASK = "text-generation";
+
+/**
+ * Creates the default Web ONNX runtime, backed by Transformers.js (which runs ONNX models through
+ * `onnxruntime-web`).
+ *
+ * ONNX Runtime GenAI has no browser build, so Transformers.js fills the generative-loop role
+ * (tokenization, sampling, KV cache) behind the `OnnxTextGenerationRuntime` seam. Applications that
+ * need a different runtime implement the seam themselves and pass it to the provider.
+ *
+ * `@huggingface/transformers` is an optional dependency the application installs: when it is absent
+ * the runtime
+ * reports itself unavailable instead of throwing, so routing degrades to an explainable
+ * `capability_unavailable` rejection.
+ *
+ * @param options - Loader, backend, and model-resolution overrides.
+ */
+export function createTransformersJsRuntime(
+  options: TransformersJsRuntimeOptions = {}
+): OnnxTextGenerationRuntime {
+  let modulePromise: Promise<TransformersModule> | undefined;
+  let generatorPromise: Promise<TransformersTextGenerator> | undefined;
+
+  async function loadModule(): Promise<TransformersModule> {
+    modulePromise ??= (options.load ?? loadTransformersModule)();
+    return modulePromise;
+  }
+
+  async function loadGenerator(modelPackage: ModelPackage): Promise<TransformersTextGenerator> {
+    generatorPromise ??= (async () => {
+      const module = await loadModule();
+      const device = resolveDevice(options.device);
+
+      if (options.createGenerator) {
+        return options.createGenerator({ modelPackage, module, device });
+      }
+
+      const modelRef = getModelRef(modelPackage);
+      if (!modelRef) {
+        throw new OnnxRuntimeError(
+          "capability",
+          "model source unavailable: the model package does not declare source.ref."
+        );
+      }
+
+      applyEnvironment(module, modelPackage, options.localModelPath);
+
+      const pipelineOptions: Record<string, unknown> = {
+        device,
+        dtype: options.dtype ?? defaultDtype(device),
+        ...(options.pipelineOptions ?? {})
+      };
+
+      return module.pipeline(TEXT_GENERATION_TASK, modelRef, pipelineOptions);
+    })();
+
+    return generatorPromise;
+  }
+
+  return {
+    async prepare(modelPackage: ModelPackage): Promise<OnnxRuntimeAvailability> {
+      let module: TransformersModule;
+      try {
+        module = await loadModule();
+      } catch (err) {
+        modulePromise = undefined;
+        return {
+          available: false,
+          reason: `runtime package unavailable: install the optional dependency @huggingface/transformers (${getErrorMessage(err)}).`
+        };
+      }
+
+      if (typeof module.pipeline !== "function") {
+        return {
+          available: false,
+          reason:
+            "runtime initialization failed: @huggingface/transformers did not expose pipeline()."
+        };
+      }
+
+      if (modelPackage.format !== "onnx") {
+        return {
+          available: false,
+          reason: `unsupported model format: the Transformers.js runtime consumes ONNX weights, received '${modelPackage.format}'.`
+        };
+      }
+
+      const sourceType = modelPackage.source?.sourceType;
+      if (sourceType === "programmatic" && !options.createGenerator) {
+        return {
+          available: false,
+          reason:
+            "model source unavailable: programmatic model packages require a createGenerator option."
+        };
+      }
+
+      if (!options.createGenerator && !getModelRef(modelPackage)) {
+        return {
+          available: false,
+          reason: "model source unavailable: the model package does not declare source.ref."
+        };
+      }
+
+      return { available: true };
+    },
+
+    async generate(
+      input: OnnxGenerationInput,
+      signal?: AbortSignal
+    ): Promise<OnnxGenerationOutput> {
+      let generator: TransformersTextGenerator;
+      try {
+        generator = await loadGenerator(input.modelPackage);
+      } catch (err) {
+        generatorPromise = undefined;
+        if (err instanceof OnnxRuntimeError) throw err;
+        if (isResourceExhaustion(err)) {
+          throw new OnnxRuntimeError(
+            "unavailable",
+            `insufficient memory to load the model: ${getErrorMessage(err)}. Try a smaller model or a more aggressive dtype (for example 'q4').`,
+            err
+          );
+        }
+        throw new OnnxRuntimeError(
+          "capability",
+          `model files missing or unreadable: ${getErrorMessage(err)}`,
+          err
+        );
+      }
+
+      if (signal?.aborted) {
+        throw new OnnxRuntimeError("timeout", "ONNX generation was aborted before it started.");
+      }
+
+      let raw: unknown;
+      try {
+        raw = await generator(input.messages, createGenerationOptions(input, signal));
+      } catch (err) {
+        throw new OnnxRuntimeError(
+          "internal",
+          `ONNX generation failed: ${getErrorMessage(err)}`,
+          err
+        );
+      }
+
+      const text = extractGeneratedText(raw);
+      if (text === undefined) {
+        throw new OnnxRuntimeError(
+          "internal",
+          "model output malformed: the Transformers.js pipeline returned no text."
+        );
+      }
+
+      return { text };
+    }
+  };
+}
+
+async function loadTransformersModule(): Promise<TransformersModule> {
+  // The specifier stays a literal so bundlers and dev servers resolve the bare package name; the
+  // `as string` cast keeps TypeScript from requiring the optional dependency's types here. Apps that
+  // do not install Transformers.js should pass their own `load` (or a different runtime) rather than
+  // relying on this default, which their bundler will fail to resolve.
+  return (await import("@huggingface/transformers" as string)) as TransformersModule;
+}
+
+/**
+ * Browser-viable weight variant. Transformers.js defaults to `fp32`, which makes ONNX Runtime
+ * allocate the full-precision model and fail session creation with an allocation error for
+ * anything but tiny models.
+ */
+function defaultDtype(device: string): string {
+  return device === "webgpu" ? "q4f16" : "q4";
+}
+
+function resolveDevice(configured?: string): string {
+  if (configured !== undefined) return configured;
+  const gpu = (globalThis as { navigator?: { gpu?: unknown } }).navigator?.gpu;
+  return gpu ? "webgpu" : "wasm";
+}
+
+function getModelRef(modelPackage: ModelPackage): string | undefined {
+  const ref = modelPackage.source?.ref;
+  return typeof ref === "string" && ref.length > 0 ? ref : undefined;
+}
+
+function applyEnvironment(
+  module: TransformersModule,
+  modelPackage: ModelPackage,
+  localModelPath?: string
+): void {
+  const env = module.env;
+  if (!env) return;
+
+  const sourceType = modelPackage.source?.sourceType;
+  if (sourceType === "bundled" || sourceType === "app_managed") {
+    env.allowLocalModels = true;
+    env.allowRemoteModels = false;
+    if (localModelPath !== undefined) {
+      env.localModelPath = localModelPath;
+    }
+  }
+}
+
+function createGenerationOptions(
+  input: OnnxGenerationInput,
+  signal?: AbortSignal
+): Record<string, unknown> {
+  const generation = input.generation;
+  const generationOptions: Record<string, unknown> = {};
+
+  if (generation?.maxOutputTokens !== undefined) {
+    generationOptions.max_new_tokens = generation.maxOutputTokens;
+  }
+  if (generation?.temperature !== undefined) {
+    generationOptions.temperature = generation.temperature;
+    generationOptions.do_sample = generation.temperature > 0;
+  }
+  if (generation?.topP !== undefined) {
+    generationOptions.top_p = generation.topP;
+  }
+  if (generation?.stop !== undefined && generation.stop.length > 0) {
+    generationOptions.stop_strings = generation.stop;
+  }
+  if (signal !== undefined) {
+    generationOptions.signal = signal;
+  }
+
+  return generationOptions;
+}
+
+function extractGeneratedText(raw: unknown): string | undefined {
+  const first = Array.isArray(raw) ? raw[0] : raw;
+  if (!isRecord(first)) {
+    return typeof first === "string" ? first : undefined;
+  }
+
+  const generated = first.generated_text;
+  if (typeof generated === "string") {
+    return generated;
+  }
+
+  if (Array.isArray(generated)) {
+    const last = generated[generated.length - 1];
+    if (isRecord(last) && typeof last.content === "string") {
+      return last.content;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Detects out-of-memory failures surfaced by ONNX Runtime session creation, which arrive as
+ * allocation errors from the WASM/native layer rather than as typed errors.
+ */
+function isResourceExhaustion(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes("bad_alloc") ||
+    message.includes("out of memory") ||
+    message.includes("failed to allocate") ||
+    message.includes("allocation failed")
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/inderun-web/src/onnx.ts
+++ b/packages/inderun-web/src/onnx.ts
@@ -1,0 +1,34 @@
+/**
+ * Provider-specific entry point for the Web member of the ONNX Runtime provider family.
+ *
+ * Kept out of the unified SDK index (`@independo/inderun-web`) so the top-level
+ * surface stays provider-agnostic. Import from `@independo/inderun-web/onnx`
+ * when registering the adapter manually or when implementing a custom
+ * `OnnxTextGenerationRuntime`; most browser apps should pass `onnx` to
+ * `createIndeRunWeb` from the main entry point instead.
+ */
+export {
+  OnnxRuntimeWebProvider,
+  DEFAULT_ONNX_WEB_PROVIDER_ID,
+  SUPPORTED_WEB_MODEL_SOURCE_TYPES,
+  type OnnxProviderOptions
+} from "./onnx-provider.js";
+
+export {
+  OnnxRuntimeError,
+  createFixtureOnnxRuntime,
+  type FixtureOnnxRuntimeOptions,
+  type OnnxGenerationInput,
+  type OnnxGenerationMessage,
+  type OnnxGenerationOutput,
+  type OnnxRuntimeAvailability,
+  type OnnxRuntimeErrorKind,
+  type OnnxTextGenerationRuntime
+} from "./onnx-runtime.js";
+
+export {
+  createTransformersJsRuntime,
+  type TransformersJsRuntimeOptions,
+  type TransformersModule,
+  type TransformersTextGenerator
+} from "./onnx-transformers-runtime.js";

--- a/packages/inderun-web/src/router.ts
+++ b/packages/inderun-web/src/router.ts
@@ -135,10 +135,17 @@ export class Router {
     const localCandidates = eligible.filter((candidate) => candidate.descriptor.type !== "cloud");
     const cloudCandidates = eligible.filter((candidate) => candidate.descriptor.type === "cloud");
 
-    const selected = eligible.find((candidate) => {
+    // Constraint filtering must apply to the whole candidate list, not just the selected provider:
+    // the remainder becomes the engine's fallback chain, and a fallback that violates the request
+    // constraints would let a `local_required` run be retried against a cloud provider.
+    const admissible = eligible.filter((candidate) => {
       const descriptor = candidate.descriptor;
       const constraints = planInput.constraints;
-      const privacy = descriptor.privacy?.dataLeavesDevice ?? descriptor.type !== "cloud";
+      // Mirrors `is_data_private` in the shared Rust planner: a provider is private when it
+      // declares that data does not leave the device, defaulting to non-cloud providers.
+      const isDataPrivate = descriptor.privacy
+        ? !descriptor.privacy.dataLeavesDevice
+        : descriptor.type !== "cloud";
 
       if (constraints.cloud === "forbidden" && descriptor.type === "cloud") {
         return false;
@@ -148,7 +155,7 @@ export class Router {
         return false;
       }
 
-      if (constraints.privacy === "local_required" && !privacy) {
+      if (constraints.privacy === "local_required" && !isDataPrivate) {
         return false;
       }
 
@@ -163,11 +170,7 @@ export class Router {
       return candidate.capabilities.available;
     });
 
-    const ordered = selected
-      ? [selected, ...eligible.filter((candidate) => candidate !== selected)]
-      : [];
-
-    if (ordered.length === 0) {
+    if (admissible.length === 0) {
       const failureSummary = this.buildFallbackFailureSummary({
         online,
         constraints: planInput.constraints,
@@ -192,18 +195,18 @@ export class Router {
       };
     }
 
-    const selectedProviderId = ordered[0]?.descriptor.id;
+    const selectedProviderId = admissible[0]?.descriptor.id;
 
     return {
       selectedProviderId,
-      fallbackProviderIds: ordered.slice(1).map((candidate) => candidate.descriptor.id),
-      candidates: ordered.map((candidate, index) => ({
+      fallbackProviderIds: admissible.slice(1).map((candidate) => candidate.descriptor.id),
+      candidates: admissible.map((candidate, index) => ({
         providerId: candidate.descriptor.id,
         order: index
       })),
       rejectedProviders: [],
       explanation: {
-        summary: `Selected provider '${selectedProviderId}' deterministically from ${ordered.length} eligible candidate(s).`,
+        summary: `Selected provider '${selectedProviderId}' deterministically from ${admissible.length} eligible candidate(s).`,
         selectedProviderId
       }
     };

--- a/packages/inderun-web/src/web-sdk.ts
+++ b/packages/inderun-web/src/web-sdk.ts
@@ -3,6 +3,7 @@ import {
   type CreateBrowserHostServicesOptions
 } from "./browser-host.js";
 import { IndeRun } from "./engine.js";
+import { OnnxRuntimeWebProvider, type OnnxProviderOptions } from "./onnx-provider.js";
 import {
   DEFAULT_OPENAI_RESPONSES_ENDPOINT,
   OpenAIResponsesProvider,
@@ -17,7 +18,12 @@ export interface CreateIndeRunWebOptions {
   /**
    * OpenAI Responses provider configuration registered by the factory.
    */
-  openAI: OpenAIProviderOptions;
+  openAI?: OpenAIProviderOptions;
+  /**
+   * Web ONNX Runtime provider configuration registered by the factory, for developer-supplied
+   * local models. Registering it is what makes `constraints.privacy = "local_required"` routable.
+   */
+  onnx?: OnnxProviderOptions;
   /**
    * Optional browser host service overrides.
    */
@@ -33,29 +39,47 @@ export interface CreateIndeRunWebOptions {
 }
 
 /**
- * Creates a Web SDK instance with the OpenAI Responses provider registered.
+ * Creates a Web SDK instance with the configured providers registered.
+ *
+ * Pass `openAI` for cloud execution, `onnx` for developer-supplied local models, or both to let
+ * routing choose between them; at least one is required.
  *
  * Use `openAI.auth = "none"` with a proxy endpoint for production browser apps so the OpenAI API key never ships
  * to the client. Direct OpenAI calls require `allowDirectOpenAIEndpoint` and should resolve credentials through
  * `authContextRef` and `SecureStorageService`.
  *
- * @param options - OpenAI provider configuration and optional host service overrides.
+ * @param options - Provider configuration and optional host service overrides.
  */
 export function createIndeRunWeb(options: CreateIndeRunWebOptions): IndeRun {
-  assertSafeOpenAIEndpoint(options);
+  if (!options.openAI && !options.onnx) {
+    throw new Error(
+      "createIndeRunWeb requires at least one provider configuration (openAI and/or onnx)."
+    );
+  }
 
   const registry = new ProviderRegistry();
-  registry.register(new OpenAIResponsesProvider(options.openAI));
+
+  if (options.openAI) {
+    assertSafeOpenAIEndpoint(options.openAI, options.allowDirectOpenAIEndpoint);
+    registry.register(new OpenAIResponsesProvider(options.openAI));
+  }
+
+  if (options.onnx) {
+    registry.register(new OnnxRuntimeWebProvider(options.onnx));
+  }
 
   return new IndeRun(registry, createBrowserHostServices(options.hostServices));
 }
 
-function assertSafeOpenAIEndpoint(options: CreateIndeRunWebOptions): void {
-  const endpointUrl = options.openAI.endpointUrl ?? DEFAULT_OPENAI_RESPONSES_ENDPOINT;
-  const auth = options.openAI.auth ?? "authContextRef";
+function assertSafeOpenAIEndpoint(
+  openAI: OpenAIProviderOptions,
+  allowDirectOpenAIEndpoint?: boolean
+): void {
+  const endpointUrl = openAI.endpointUrl ?? DEFAULT_OPENAI_RESPONSES_ENDPOINT;
+  const auth = openAI.auth ?? "authContextRef";
   const isDirectOpenAIEndpoint = isOpenAIResponsesEndpoint(endpointUrl);
 
-  if (isDirectOpenAIEndpoint && auth !== "none" && !options.allowDirectOpenAIEndpoint) {
+  if (isDirectOpenAIEndpoint && auth !== "none" && !allowDirectOpenAIEndpoint) {
     throw new Error(
       'createIndeRunWeb is proxy-first for browser safety. Configure openAI.endpointUrl to a server-side proxy with auth: "none", or set allowDirectOpenAIEndpoint: true for controlled direct OpenAI calls.'
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
 
   packages/inderun-web:
     dependencies:
+      '@huggingface/transformers':
+        specifier: ^4.0.0
+        version: 4.2.0
       '@independo/inderun-contracts':
         specifier: workspace:^
         version: link:../contracts
@@ -103,6 +106,9 @@ importers:
 
   packages/inderun-web-demo:
     dependencies:
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@independo/inderun-contracts':
         specifier: workspace:^
         version: link:../contracts
@@ -156,6 +162,9 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -358,6 +367,16 @@ packages:
   '@glideapps/ts-necessities@2.4.0':
     resolution: {integrity: sha512-mDC+qosuNa4lxR3ioMBb6CD0XLRsQBplU+zRPUYiMLXKeVPZ6UYphdNG/EGReig0YyfnVlBKZEXl1wzTotYmPA==}
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -377,6 +396,159 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -513,6 +685,33 @@ packages:
   '@pnpm/npm-conf@3.0.3':
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -909,6 +1108,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1001,6 +1204,10 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -1221,8 +1428,23 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -1271,8 +1493,19 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1447,6 +1680,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
@@ -1509,13 +1745,25 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globals@17.7.0:
     resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -1526,6 +1774,9 @@ packages:
   graphql@16.14.2:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -1543,6 +1794,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -1805,6 +2059,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1846,6 +2103,10 @@ packages:
     resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
     engines: {node: '>= 16'}
     hasBin: true
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -2094,6 +2355,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2104,6 +2369,19 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2253,6 +2531,9 @@ packages:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -2283,6 +2564,10 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-agent-negotiate@1.1.0:
     resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
@@ -2384,6 +2669,10 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2412,6 +2701,9 @@ packages:
     engines: {node: ^22.14.0 || >= 24.10.0}
     hasBin: true
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver-diff@4.0.0:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
@@ -2424,6 +2716,14 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2484,6 +2784,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2658,6 +2961,9 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
@@ -2665,6 +2971,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
@@ -3003,6 +3313,11 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -3119,6 +3434,18 @@ snapshots:
 
   '@glideapps/ts-necessities@2.4.0': {}
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3134,6 +3461,102 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -3293,6 +3716,26 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -3768,6 +4211,8 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  adm-zip@0.5.18: {}
+
   agent-base@7.1.4: {}
 
   agent-base@9.0.0: {}
@@ -3841,6 +4286,8 @@ snapshots:
   before-after-hook@2.2.3: {}
 
   before-after-hook@4.0.0: {}
+
+  boolean@3.2.0: {}
 
   bottleneck@2.19.5: {}
 
@@ -4069,7 +4516,23 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   deprecation@2.3.1: {}
+
+  detect-libc@2.1.2: {}
+
+  detect-node@2.1.0: {}
 
   diff@4.0.4: {}
 
@@ -4111,7 +4574,13 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es6-error@4.1.1: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4338,6 +4807,8 @@ snapshots:
       flatted: 3.4.4
       keyv: 4.5.4
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.4: {}
 
   from2@2.3.0:
@@ -4400,7 +4871,21 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.5
+      serialize-error: 7.0.1
+
   globals@17.7.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
 
   globby@14.1.0:
     dependencies:
@@ -4411,11 +4896,15 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.3.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
 
   graphql@16.14.2: {}
+
+  guid-typescript@1.0.9: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -4442,6 +4931,10 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   highlight.js@10.7.3: {}
 
@@ -4672,6 +5165,8 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -4714,6 +5209,10 @@ snapshots:
   marked@15.0.12: {}
 
   marked@9.1.6: {}
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
 
   meow@12.1.1: {}
 
@@ -4802,6 +5301,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-keys@1.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4813,6 +5314,25 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.18
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.5
 
   optionator@0.9.4:
     dependencies:
@@ -4933,6 +5453,8 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
+  platform@1.3.6: {}
+
   pluralize@8.0.0: {}
 
   postcss@8.5.15:
@@ -4954,6 +5476,20 @@ snapshots:
   process@0.11.10: {}
 
   proto-list@1.2.4: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.1.2
+      long: 5.3.2
 
   proxy-agent-negotiate@1.1.0: {}
 
@@ -5106,6 +5642,15 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+
   rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
@@ -5217,6 +5762,8 @@ snapshots:
       - supports-color
       - typescript
 
+  semver-compare@1.0.0: {}
+
   semver-diff@4.0.0:
     dependencies:
       semver: 7.8.5
@@ -5224,6 +5771,41 @@ snapshots:
   semver-regex@4.0.5: {}
 
   semver@7.8.5: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -5274,6 +5856,8 @@ snapshots:
       through2: 2.0.5
 
   split2@4.2.0: {}
+
+  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
@@ -5442,11 +6026,16 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  tslib@2.8.1:
+    optional: true
+
   tunnel@0.0.6: {}
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.13.1: {}
 
   type-fest@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - "packages/*"
 allowBuilds:
   esbuild: true
+  # Node-only extras pulled in by @huggingface/transformers. The demo runs the ONNX provider in the
+  # browser, so these native builds are never used.
+  onnxruntime-node: false
+  protobufjs: false
+  sharp: false


### PR DESCRIPTION
Closes #85

Implements the Web member of the ONNX Runtime provider family specified in #32, so browser apps can route `text_to_text` through developer-supplied local ONNX models. Registering it is what makes `constraints.privacy = "local_required"` routable on Web.

## What ships

- **`OnnxRuntimeWebProvider`** (`local.onnx.genai.web`): `type: local`, `in_process`, Mode 1 `run` only, `cancel: soft`, `privacy.dataLeavesDevice: false`.
- **Capability gates**, in order: `ModelPackage` schema validation (reusing `getModelPackageValidationIssues`, including its inline-secret and URL-userinfo rules) → Web source-type support → `runtime.platforms` → declared tasks → the runtime. Every failure flattens to a single `capability_unavailable` rejection carrying the reason string.
- **`OnnxTextGenerationRuntime` seam** plus `OnnxRuntimeError`, whose `kind` (`capability`/`unavailable`/`timeout`/`internal`) selects the IndeRun error class. Two implementations: `createTransformersJsRuntime` (default) and `createFixtureOnnxRuntime` (deterministic test seam and offline demo path).
- **Web model sources**: `registry`, `bundled`, `programmatic`, `app_managed`. `filesystem` rejected as unsupported, `remote` as deferred, per the family matrix.
- Exposed via the **`./onnx` subpath**, kept out of the provider-agnostic root index like the OpenAI adapter. `createIndeRunWeb` now takes `openAI` and/or `onnx` and requires at least one.

## Spec correction: ONNX Runtime GenAI has no browser build

#32 mandates ORT GenAI as the first runtime path. It ships Python/.NET/C++/Java only, and `onnxruntime-web` provides raw inference without a generative loop. The Web member therefore satisfies the *role* GenAI was mandated for by defaulting to Transformers.js, which runs ONNX models on `onnxruntime-web` and owns the generation loop. This is precisely what the injectable seam exists for; the mobile members (#86/#87) are unaffected. Recorded in `docs/architecture/onnx-runtime-provider-family.md`.

## Drive-by fixes (both found by running the demo, not by tests)

Two defects in the TypeScript fallback route planner, both unreachable until a local Web provider existed:

1. The `local_required` check read `dataLeavesDevice` **without negating it**, so it rejected local providers and admitted cloud ones.
2. Constraint filtering applied **only to the selected provider**, leaving the fallback chain unfiltered — a failing `local_required` attempt was retried against a cloud provider, defeating the privacy constraint.

Both now mirror the shared Rust planner (`is_data_private`, and filtering candidates before building the chain). Regression tests cover each.

Also: the default runtime loads quantized weights (`q4f16` on WebGPU, `q4` otherwise). Transformers.js would otherwise select `fp32`, which makes ONNX Runtime fail session creation with `std::bad_alloc` for all but tiny models. Allocation failures map to `Unavailable` (resource exhaustion), not `CapabilityMismatch`.

## Dependency handling

`@huggingface/transformers` is an optional peer dependency the application installs; pnpm's strict layout needs the peer declaration for the specifier to resolve from inside `inderun-web`. Its Node-only native transitive deps (`onnxruntime-node`, `protobufjs`, `sharp`) have build scripts disallowed in `pnpm-workspace.yaml` since the browser never uses them.

## Verification

- 106 JS tests pass across the four packages; `pnpm build`, `pnpm lint` (0 errors), prettier clean.
- **End-to-end in Chrome** against `onnx-community/gemma-3-1b-it-ONNX`: real on-device generation in reasonable time, `telemetry.providerUsed = local.onnx.genai.web`.
- Rust/Kotlin/Swift are untouched and were not run locally; CI runs them per-language.

## Follow-up (not in this PR)

The shared Rust route planner **silently never loads in browser builds**. `route-planner.ts` imports it via a bare specifier behind `/* @vite-ignore */`, so bundlers leave it unresolved; the import throws, the `catch` returns `null`, and the engine degrades to the TypeScript fallback planner. Confirmed in both Vite output and Node. That is why the two planner bugs above were live at all. Pre-existing and out of scope here — worth its own issue, since the Rust core is currently effectively dead code on Web and the two planners only stay consistent by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)