### PR TITLE
feat(ios): Apple ONNX Runtime provider for developer-supplied models

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "onnxruntime-swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/onnxruntime-swift-package-manager",
+      "state" : {
+        "revision" : "b7fb7f7dea8a2469e6335d95a61b8f36d0dc83b2",
+        "version" : "1.24.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ import PackageDescription
 let package = Package(
     name: "IndeRun",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v12)
+        .iOS(.v16),
+        .macOS(.v14)
     ],
     products: [
         .library(
@@ -31,9 +31,20 @@ let package = Package(
         .library(
             name: "IndeRunOpenAIProviders",
             targets: ["IndeRunOpenAIProviders"]
+        ),
+        .library(
+            name: "IndeRunOnnxProviders",
+            targets: ["IndeRunOnnxProviders"]
         )
     ],
-    dependencies: [],
+    dependencies: [
+        // ONNX Runtime C/Objective-C bindings for the Apple ONNX Runtime provider family member.
+        // macOS 14 / iOS 16 (this package's platform minimums) are required by this dependency.
+        .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager", from: "1.24.2"),
+        // Hugging Face tokenizer parsing, used by the default ONNX runtime to tokenize model input
+        // without hand-rolling a tokenizer implementation.
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3")
+    ],
     targets: [
         .target(
             name: "IndeRunContracts",
@@ -60,9 +71,26 @@ let package = Package(
             dependencies: ["IndeRunCore", "IndeRunContracts"],
             path: "ios/IndeRun/Sources/IndeRunOpenAIProviders"
         ),
+        .target(
+            name: "IndeRunOnnxProviders",
+            dependencies: [
+                "IndeRunCore",
+                "IndeRunContracts",
+                .product(name: "onnxruntime", package: "onnxruntime-swift-package-manager"),
+                .product(name: "Tokenizers", package: "swift-transformers")
+            ],
+            path: "ios/IndeRun/Sources/IndeRunOnnxProviders"
+        ),
         .testTarget(
             name: "IndeRunTests",
-            dependencies: ["IndeRunSwift", "IndeRunContracts", "IndeRunCore", "IndeRunAppleProviders", "IndeRunOpenAIProviders"],
+            dependencies: [
+                "IndeRunSwift",
+                "IndeRunContracts",
+                "IndeRunCore",
+                "IndeRunAppleProviders",
+                "IndeRunOpenAIProviders",
+                "IndeRunOnnxProviders"
+            ],
             path: "ios/IndeRun/Tests/IndeRunTests"
         )
     ]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ provider ships from the `@independo/inderun-web/onnx` subpath.
 
 **Requirements:**
 
-- SDK: iOS 15+ / macOS 12+, Swift 5.9+ (Swift Package Manager).
+- SDK: iOS 16+ / macOS 14+, Swift 5.9+ (Swift Package Manager).
 - On-device provider (Apple Foundation Models): an Apple Intelligence–capable device running a FoundationModels-supported
   OS (iOS 26+ / macOS 26+). Availability is checked at runtime; IndeRun falls back to the cloud provider when it is
   unavailable. **No special Info.plist entitlement is required** for on-device execution.
@@ -170,7 +170,7 @@ and consumes the SDKs published from this monorepo (npm, SwiftPM git tag, Maven 
 | Platform     | SDK minimum                                    | On-device local model                                  |
 | ------------ | ---------------------------------------------- | ------------------------------------------------------ |
 | Web          | Node 24+ / modern browser (ES2022 + WASM)      | — (cloud provider only)                                |
-| iOS / macOS  | iOS 15+ / macOS 12+, Swift 5.9+                | Apple Intelligence device, iOS 26+ / macOS 26+         |
+| iOS / macOS  | iOS 16+ / macOS 14+, Swift 5.9+                | Apple Intelligence device, iOS 26+ / macOS 26+         |
 | Android      | Android 8.0+ (API 26), JDK 17                  | Device with AICore / Gemini Nano support               |
 
 The OpenAI-compatible cloud provider is available on every platform. On-device execution additionally requires the

--- a/docs/architecture/onnx-runtime-provider-family.md
+++ b/docs/architecture/onnx-runtime-provider-family.md
@@ -6,8 +6,9 @@ architecture baseline for the platform implementation tickets: #85 (Web), #87 (A
 (Apple platforms). Those tickets implement providers; they must not re-decide the boundaries below.
 
 This is a Milestone 2 specification. Field-level shapes live in the schema, not in this prose (see
-[Model Package Contract](#model-package-contract)). The Web member is implemented; Android and Apple
-are not yet (see [Web Implementation](#web-implementation)).
+[Model Package Contract](#model-package-contract)). The Web and Apple members are implemented;
+Android is not yet (see [Web Implementation](#web-implementation) and
+[Apple Implementation](#apple-implementation)).
 
 ## Classification And Boundaries
 
@@ -267,6 +268,78 @@ and caching model and ORT WASM assets; IndeRun owns no download or cache layer i
 `ProviderAdapter` when the model is ONNX: the provider already owns descriptor semantics, model
 package validation, source gating, timeouts, and error normalization. Implement `ProviderAdapter`
 directly only for a different runtime family.
+
+## Apple Implementation
+
+The Apple member ships as its own SwiftPM library product, `IndeRunOnnxProviders`
+(`ios/IndeRun/Sources/IndeRunOnnxProviders`), kept out of `IndeRunSwift`/`IndeRunAppleProviders`
+like the Web member is kept out of the provider-agnostic root index. Provider id:
+`local.onnx.genai.apple`. Descriptor: `type: .local`, `transport: .inProcess`, `supports.run:
+true` with all forward-looking flags false, `cancel: .soft`, `privacy.dataLeavesDevice: false`.
+
+**Platform minimums.** Landing this member raised the whole SDK's minimum platforms from iOS 15 /
+macOS 12 to **iOS 16 / macOS 14**, because its dependencies require it: the official ONNX Runtime
+SPM bindings (`microsoft/onnxruntime-swift-package-manager`, macOS 14 minimum) and
+`swift-transformers`'s `Tokenizers` module (iOS 16 minimum). SwiftPM has no per-target platform
+override in a single manifest, so this is a package-wide, breaking bump — every IndeRun Apple
+consumer, not only ONNX users, now needs iOS 16 / macOS 14.
+
+**Runtime seam.** `OnnxGenAiRuntime` has two methods: `prepare(_:)` returning the `{available,
+reason?}` snapshot, and `generate(_:)` returning normalized text — the same shape as the Web
+member's `OnnxTextGenerationRuntime`, adapted to Swift Concurrency (cancellation is ambient via
+`Task` cancellation rather than an explicit `AbortSignal` parameter). Two implementations exist:
+
+- `SystemOnnxGenAiRuntime()` — the default. Tokenizes with `swift-transformers`'s
+  `AutoTokenizer.from(modelFolder:)` and runs inference through the official ONNX Runtime SPM
+  bindings (`OnnxRuntimeBindings` / `ORTSession`). **IO contract**: the model graph must expose
+  exactly `input_ids` and `attention_mask` inputs (`int64`, `[1, sequenceLength]`) and a `logits`
+  output (`float32`, `[1, sequenceLength, vocabSize]`) — the plain decoder-only export shape,
+  without `past_key_values`. Decoding is **greedy (argmax) with no KV-cache reuse**: the full
+  sequence is recomputed on every generated token. This is a real, documented performance
+  limitation, not a hidden one — apps that need throughput, sampling, or the
+  `past_key_values`/Hugging Face Optimum export convention supply their own `OnnxGenAiRuntime`.
+  `programmatic` model sources are also out of scope for this default runtime (no files to
+  resolve, matching the Web member's own `programmatic` carve-out); it reports *runtime package
+  unavailable* rather than throwing.
+- `createFixtureOnnxRuntime(options:)` — the deterministic in-memory fixture mandated above,
+  public/importable like the Web member's `createFixtureOnnxRuntime` (this diverges deliberately
+  from the private-to-tests fixture convention used by `AppleFoundationModelsProvider`, per the
+  fixture's explicit mandate to support offline demos as well as tests).
+- Any application-supplied implementation of `OnnxGenAiRuntime`.
+
+**Model sources.** The Apple member honors `bundled`, `programmatic`, `app_managed`, and
+`filesystem`, and rejects `registry` and `remote` in `capabilities()`, matching the support
+matrix above. `SystemOnnxGenAiRuntime` resolves `bundled` under `Bundle.main.resourceURL`,
+`filesystem` and `app_managed` as a directory path from `source.ref` (absolute for `filesystem`,
+relative to the app's Application Support directory for `app_managed`).
+
+**Capability gate order.** Model package structural validation (a hand-written
+`getModelPackageValidationIssues` in `IndeRunOnnxProviders` — no generated JSON Schema validator
+exists in Swift, so this is a scoped subset covering `id`/`format` presence, inline-secret keys,
+and `source.ref` URL-userinfo, not a full AJV-equivalent port) → Apple source-type support →
+`runtime.platforms` includes `apple` → declared tasks include `text_to_text` → delegate to
+`runtime.prepare`. Every failure flattens to one `capability_unavailable` route rejection, for
+example:
+
+- `capability_unavailable`: *model source unavailable: 'registry' model sources are deferred on
+  Apple platforms; supply model files as bundled, programmatic, app_managed, filesystem.*
+- `capability_unavailable`: *model files missing: 'model.onnx' not found at \<resolved path\>.*
+- `CapabilityMismatch` at run time when the same gate fails pre-attempt; `Timeout` when the
+  generation budget (`constraints.timeoutMs`, else the provider's configured timeout) elapses or
+  the request is cancelled; `Unavailable` for ONNX Runtime session initialization failures. There
+  is no `AuthError`, `RateLimited`, or `Offline` path.
+
+**Packaging and binary size.** ORT Mobile's native binary is statically linked via the SPM
+`onnxruntime` product and adds meaningfully to app binary size; the model files themselves must
+also fit on-device disk and load into device memory (see
+[Platform Constraints](#platform-constraints-reference)). Neither IndeRun nor this provider owns
+model download/update flows in Milestone 2 — apps that fetch models remotely still supply them as
+`bundled`/`app_managed`/`programmatic` once resolved, per the model source matrix.
+
+**Authoring a custom local provider.** Implement `OnnxGenAiRuntime` rather than a new
+`ProviderAdapter` when the model is ONNX: `OnnxRuntimeAppleProvider` already owns descriptor
+semantics, model package validation, source gating, timeouts, and error normalization. Implement
+`ProviderAdapter` directly only for a different runtime family, mirroring the Web guidance above.
 
 ## Documentation Requirements For Platform Tickets (#85–#87)
 

--- a/docs/architecture/onnx-runtime-provider-family.md
+++ b/docs/architecture/onnx-runtime-provider-family.md
@@ -290,14 +290,29 @@ member's `OnnxTextGenerationRuntime`, adapted to Swift Concurrency (cancellation
 `Task` cancellation rather than an explicit `AbortSignal` parameter). Two implementations exist:
 
 - `SystemOnnxGenAiRuntime()` — the default. Tokenizes with `swift-transformers`'s
-  `AutoTokenizer.from(modelFolder:)` and runs inference through the official ONNX Runtime SPM
+  `AutoTokenizer.from(modelFolder:)`, applying the tokenizer's chat template
+  (`Tokenizer.applyChatTemplate`) when `tokenizer_config.json` declares one and falling back to a
+  plain `"role: content"` join otherwise; runs inference through the official ONNX Runtime SPM
   bindings (`OnnxRuntimeBindings` / `ORTSession`). **IO contract**: the model graph must expose
   exactly `input_ids` and `attention_mask` inputs (`int64`, `[1, sequenceLength]`) and a `logits`
   output (`float32`, `[1, sequenceLength, vocabSize]`) — the plain decoder-only export shape,
-  without `past_key_values`. Decoding is **greedy (argmax) with no KV-cache reuse**: the full
-  sequence is recomputed on every generated token. This is a real, documented performance
-  limitation, not a hidden one — apps that need throughput, sampling, or the
-  `past_key_values`/Hugging Face Optimum export convention supply their own `OnnxGenAiRuntime`.
+  without `past_key_values`. **Graph file convention**: `ModelPackage.files.required` has no
+  positional semantics of its own in the schema, so this runtime defines one — the *first* entry
+  is the ONNX graph file; any remaining entries (for example external weight shards) must be
+  present alongside it but are not referenced directly. `ModelPackage.integrity.checksums`
+  (`sha256:<hex>`) are verified for every file this runtime resolves, before load. The session
+  cache key covers `id`, `version`, `source`, and `integrity.checksums` together, not `id` alone,
+  so swapping a model's bytes without bumping `id` does not silently keep serving a stale session.
+  Decoding is **greedy (argmax) with no KV-cache reuse**: the full sequence is recomputed on every
+  generated token, with no CoreML execution provider, shared `ORTEnv`, or thread-pool policy
+  configured. This is a real, documented performance limitation, not a hidden one — CPU-only,
+  unoptimized. `generation.stop` sequences are honored; `temperature`/`topP`/`seed` are not (no
+  sampling, argmax only). Apps that need throughput, sampling, an accelerated execution provider,
+  or the `past_key_values`/Hugging Face Optimum export convention supply their own
+  `OnnxGenAiRuntime`; hardening this default runtime (CoreML EP, shared environment, thread
+  policy, buffer reuse, KV-cache) is tracked in #126, and real-device verification (load time,
+  token latency, peak memory, cancellation behavior, repeated-run stability against an actual
+  model) is tracked in #88 — this default has not yet been run against a real model on-device.
   `programmatic` model sources are also out of scope for this default runtime (no files to
   resolve, matching the Web member's own `programmatic` carve-out); it reports *runtime package
   unavailable* rather than throwing.
@@ -325,9 +340,17 @@ example:
   Apple platforms; supply model files as bundled, programmatic, app_managed, filesystem.*
 - `capability_unavailable`: *model files missing: 'model.onnx' not found at \<resolved path\>.*
 - `CapabilityMismatch` at run time when the same gate fails pre-attempt; `Timeout` when the
-  generation budget (`constraints.timeoutMs`, else the provider's configured timeout) elapses or
-  the request is cancelled; `Unavailable` for ONNX Runtime session initialization failures. There
-  is no `AuthError`, `RateLimited`, or `Offline` path.
+  generation budget (`constraints.timeoutMs`, else the provider's configured timeout) elapses;
+  `Unavailable` for ONNX Runtime session initialization failures. There is no `AuthError`,
+  `RateLimited`, or `Offline` path. Real `Task` cancellation (the caller cancelling its own task,
+  as opposed to the provider's own deadline elapsing) propagates as a raw `CancellationError`
+  rather than an `IndeRunException`, matching the established Swift-side convention
+  (`OpenAIProvider`, `IndeRun.swift`) rather than the Web member's `AbortError → Timeout` mapping —
+  the two platforms differ here because Swift Concurrency has first-class cancellation and the
+  rest of this SDK already relies on it. `ORTSession.run()` itself is a blocking synchronous call
+  that cannot be interrupted mid-call; cancellation is observed only between decode steps
+  (`cancel: .soft`), so a cancelled or timed-out request still waits out its current in-flight
+  step.
 
 **Packaging and binary size.** ORT Mobile's native binary is statically linked via the SPM
 `onnxruntime` product and adds meaningfully to app binary size; the model files themselves must

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -53,7 +53,10 @@ factories), not in prose.
 - Custom/developer-supplied local models: ONNX Runtime provider family (Milestone 2, specified in
   [onnx-runtime-provider-family.md](onnx-runtime-provider-family.md))
   - Web on-device: `local.onnx.genai.web`, shipped in `@independo/inderun-web/onnx`
-  - Android and Apple members are not implemented yet (#87/#86)
+  - Apple on-device: `local.onnx.genai.apple`, shipped in the `IndeRunOnnxProviders` SwiftPM
+    library product; raised the SDK's Apple platform minimums to iOS 16 / macOS 14 (see
+    [Apple Implementation](onnx-runtime-provider-family.md#apple-implementation))
+  - Android member is not implemented yet (#87)
 - Browser-managed on-device models: Web system-model provider family (Milestone 2, specified in
   [web-system-model-provider-family.md](web-system-model-provider-family.md)) — the browser owns
   model availability/download/execution, unlike the developer-supplied ONNX family

--- a/ios/IndeRun/README.md
+++ b/ios/IndeRun/README.md
@@ -9,6 +9,11 @@ The package is split into public API, core engine, contracts, and provider targe
 - `IndeRunSwift` - public SDK entrypoint
 - `IndeRunAppleProviders` - Apple Foundation Models provider
 - `IndeRunOpenAIProviders` - OpenAI-compatible cloud provider
+- `IndeRunOnnxProviders` - ONNX Runtime provider family member for developer-supplied/custom
+  local models (see `docs/architecture/onnx-runtime-provider-family.md`)
+
+Requires iOS 16+ / macOS 14+ (raised from iOS 15 / macOS 12 by `IndeRunOnnxProviders`'s
+dependencies: the official ONNX Runtime SPM bindings and `swift-transformers`).
 
 ## Usage
 
@@ -37,11 +42,35 @@ let result = try await inderun.run(request: TaskRequest(
 ))
 ```
 
+### Custom local ONNX models
+
+```swift
+import IndeRunOnnxProviders
+
+let modelPackage = ModelPackage(
+    files: Files(config: nil, external: nil, filesRequired: ["model.onnx"], tokenizer: "tokenizer.json"),
+    format: .onnx,
+    id: "my-onnx-model",
+    integrity: nil, license: nil, limits: nil, runtime: nil,
+    source: Source(ref: "my-model", sourceType: .bundled),
+    tasks: ["text_to_text"],
+    version: "1.0"
+)
+try registry.register(OnnxRuntimeAppleProvider(options: OnnxProviderOptions(modelPackage: modelPackage)))
+```
+
+Defaults to `SystemOnnxGenAiRuntime` (official ONNX Runtime SPM bindings + `swift-transformers`
+tokenization, greedy decoding, no KV-cache reuse). Pass `runtime:` in `OnnxProviderOptions` to
+supply a different `OnnxGenAiRuntime` implementation, or `createFixtureOnnxRuntime()` for demos
+and tests. See `docs/architecture/onnx-runtime-provider-family.md#apple-implementation` for the
+model IO contract, source-type support, and error mapping.
+
 ## Notes
 
 - Keep credentials behind `authContextRef`.
 - Use the Apple provider for on-device Mode 1 execution when the system runtime is available.
 - Use the OpenAI provider for OpenAI-compatible cloud execution through a host-provided HTTP client.
+- Use the ONNX Runtime provider for developer-supplied/custom local models.
 
 ## Commands
 

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/FixtureOnnxGenAiRuntime.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/FixtureOnnxGenAiRuntime.swift
@@ -1,0 +1,71 @@
+import Foundation
+import IndeRunContracts
+
+/// Configuration for the deterministic fixture runtime.
+public struct FixtureOnnxRuntimeOptions: Sendable {
+    /// Availability snapshot returned by `prepare`. Defaults to `{ available: true }`.
+    public var availability: OnnxRuntimeAvailability
+    /// Text or full output produced by `generate`. Defaults to a deterministic echo.
+    public var respond: (@Sendable (OnnxGenerationInput) -> OnnxGenerationOutput)?
+    /// Error thrown by `generate` instead of producing output.
+    public var failWith: OnnxRuntimeError?
+    /// Artificial generation delay, used to exercise timeouts via task cancellation.
+    public var delay: Duration?
+
+    public init(
+        availability: OnnxRuntimeAvailability = OnnxRuntimeAvailability(available: true),
+        respond: (@Sendable (OnnxGenerationInput) -> OnnxGenerationOutput)? = nil,
+        failWith: OnnxRuntimeError? = nil,
+        delay: Duration? = nil
+    ) {
+        self.availability = availability
+        self.respond = respond
+        self.failWith = failWith
+        self.delay = delay
+    }
+}
+
+/// Creates a deterministic in-memory ONNX runtime.
+///
+/// This is the test seam mandated by the ONNX Runtime provider family specification: it proves
+/// the model package contract, capability checks, routing, and error normalization without
+/// depending on a real ONNX runtime, and it lets apps exercise the on-device route in demos
+/// without bundling a model. It is deliberately public/importable, matching the Web member's
+/// `createFixtureOnnxRuntime` rather than keeping fixtures private to the test target.
+///
+/// - Parameter options: Scripted availability, response, failure, and delay behavior.
+public func createFixtureOnnxRuntime(options: FixtureOnnxRuntimeOptions = FixtureOnnxRuntimeOptions()) -> any OnnxGenAiRuntime {
+    FixtureOnnxGenAiRuntime(options: options)
+}
+
+private struct FixtureOnnxGenAiRuntime: OnnxGenAiRuntime {
+    let options: FixtureOnnxRuntimeOptions
+
+    func prepare(_ modelPackage: ModelPackage) async -> OnnxRuntimeAvailability {
+        options.availability
+    }
+
+    func generate(_ input: OnnxGenerationInput) async throws -> OnnxGenerationOutput {
+        if let delay = options.delay {
+            try await Task.sleep(for: delay)
+        }
+
+        try Task.checkCancellation()
+
+        if let failWith = options.failWith {
+            throw failWith
+        }
+
+        if let respond = options.respond {
+            return respond(input)
+        }
+
+        return OnnxGenerationOutput(text: createFixtureText(modelPackage: input.modelPackage, messages: input.messages))
+    }
+}
+
+private func createFixtureText(modelPackage: ModelPackage, messages: [OnnxGenerationMessage]) -> String {
+    let lastUserMessage = messages.last { $0.role == .user }
+    let prompt = lastUserMessage?.content ?? ""
+    return "[fixture:\(modelPackage.id)] \(prompt)"
+}

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/ModelPackageValidation.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/ModelPackageValidation.swift
@@ -1,0 +1,76 @@
+import Foundation
+import IndeRunContracts
+
+/// A single model package validation problem.
+public struct ModelPackageValidationIssue: Equatable, Sendable {
+    /// JSON-pointer-style path to the offending field, for example `/source/ref`.
+    public let path: String
+    /// Human-readable description of the problem.
+    public let message: String
+}
+
+/// Minimal structural validation for `ModelPackage`, mirroring the subset of
+/// `getModelPackageValidationIssues` (`packages/contracts/src/validators.ts`) that the provider's
+/// capability gate needs: the schema's `required` fields, the inline-secret-key rule, and the
+/// `source.ref` URL-userinfo rule. This is a hand-written subset, not a generated JSON Schema
+/// validator (no AJV-equivalent exists in Swift) -- see the ONNX Runtime provider family spec
+/// for the normative field shapes in `contracts/schemas/model-package.schema.json`.
+public func getModelPackageValidationIssues(_ modelPackage: ModelPackage) -> [ModelPackageValidationIssue] {
+    var issues: [ModelPackageValidationIssue] = []
+
+    if modelPackage.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        issues.append(ModelPackageValidationIssue(path: "/id", message: "must not be empty"))
+    }
+
+    if let ref = modelPackage.source?.ref, containsUrlUserinfo(ref) {
+        issues.append(
+            ModelPackageValidationIssue(
+                path: "/source/ref",
+                message: "must not contain credentials (URL userinfo); use authContextRef instead"
+            )
+        )
+    }
+
+    issues.append(contentsOf: findInlineSecretKeys(in: modelPackage))
+
+    return issues
+}
+
+/// Mirrors `isForbiddenSecretKey` in `packages/contracts/src/validators.ts`: rejects keys whose
+/// normalized form contains a credential-shaped substring. `ModelPackage`'s known fields never
+/// legitimately hold secrets, so this only guards `Files.external`/`Integrity.checksums`-style
+/// free-form maps a caller might misuse.
+private func findInlineSecretKeys(in modelPackage: ModelPackage) -> [ModelPackageValidationIssue] {
+    var issues: [ModelPackageValidationIssue] = []
+
+    if let checksums = modelPackage.integrity?.checksums {
+        for key in checksums.keys where isForbiddenSecretKey(key) {
+            issues.append(
+                ModelPackageValidationIssue(
+                    path: "/integrity/checksums/\(key)",
+                    message: "inline secrets are not allowed; use authContextRef instead"
+                )
+            )
+        }
+    }
+
+    return issues
+}
+
+private func isForbiddenSecretKey(_ key: String) -> Bool {
+    let normalized = key.lowercased().filter { $0.isLetter || $0.isNumber }
+    return normalized.contains("authorization")
+        || normalized.contains("password")
+        || normalized.contains("secret")
+        || normalized.contains("apikey")
+}
+
+/// Mirrors the `source.ref` schema pattern
+/// `^(?![\s\S]*://[^/@]*@)[\s\S]*$`: rejects any `scheme://userinfo@host` shape.
+private func containsUrlUserinfo(_ value: String) -> Bool {
+    guard let schemeRange = value.range(of: "://") else { return false }
+    let afterScheme = value[schemeRange.upperBound...]
+    guard let atIndex = afterScheme.firstIndex(of: "@") else { return false }
+    let authority = afterScheme[afterScheme.startIndex..<atIndex]
+    return !authority.contains("/")
+}

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxGenAiRuntime.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxGenAiRuntime.swift
@@ -1,0 +1,111 @@
+import Foundation
+import IndeRunContracts
+
+/// Availability snapshot reported by an ONNX text generation runtime.
+///
+/// The `reason` string uses the provider-internal capability vocabulary documented in
+/// `docs/architecture/onnx-runtime-provider-family.md`. It is not a public enum: the provider
+/// flattens every failure into a single `capability_unavailable` route rejection and carries the
+/// reason as human-readable text.
+public struct OnnxRuntimeAvailability: Equatable, Sendable {
+    /// Whether the runtime can execute the given model package on this host right now.
+    public let available: Bool
+    /// Human-readable detail describing why the runtime is unavailable.
+    public let reason: String?
+
+    public init(available: Bool, reason: String? = nil) {
+        self.available = available
+        self.reason = reason
+    }
+}
+
+/// Normalized conversation turn handed to an ONNX text generation runtime.
+public struct OnnxGenerationMessage: Equatable, Sendable {
+    /// The role of the author of this turn.
+    public let role: Role
+    /// Plain-text content of this turn.
+    public let content: String
+
+    public init(role: Role, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+/// Normalized generation request handed to an ONNX text generation runtime.
+public struct OnnxGenerationInput: Sendable {
+    /// The model package the provider was configured with.
+    public let modelPackage: ModelPackage
+    /// Conversation turns, normalized from `prompt` or `messages` by the provider.
+    public let messages: [OnnxGenerationMessage]
+    /// Optional generation controls copied from the task request.
+    public let generation: Generation?
+
+    public init(modelPackage: ModelPackage, messages: [OnnxGenerationMessage], generation: Generation? = nil) {
+        self.modelPackage = modelPackage
+        self.messages = messages
+        self.generation = generation
+    }
+}
+
+/// Normalized generation result returned by an ONNX text generation runtime.
+public struct OnnxGenerationOutput: Sendable {
+    /// The generated text.
+    public let text: String
+    /// Optional normalized finish reason; the provider defaults to `.stop`.
+    public let finishReason: FinishReason?
+    /// Optional token accounting, when the runtime reports it.
+    public let usage: Usage?
+
+    public init(text: String, finishReason: FinishReason? = nil, usage: Usage? = nil) {
+        self.text = text
+        self.finishReason = finishReason
+        self.usage = usage
+    }
+}
+
+/// Failure category a runtime can signal so the provider maps it onto the IndeRun error taxonomy.
+///
+/// - `capability`: model or runtime cannot serve this request (`CapabilityMismatch`).
+/// - `unavailable`: runtime initialization failure or resource exhaustion (`Unavailable`).
+/// - `timeout`: generation exceeded its budget or was cancelled (`Timeout`).
+/// - `internal`: unexpected runtime failure (`Internal`).
+public enum OnnxRuntimeErrorKind: Sendable {
+    case capability
+    case unavailable
+    case timeout
+    case internalFailure
+}
+
+/// Error type ONNX runtime implementations throw to steer IndeRun error normalization.
+///
+/// Anything else thrown by a runtime is normalized to `Internal`.
+public struct OnnxRuntimeError: Error, Sendable {
+    /// Failure category used by the provider to select an IndeRun error class.
+    public let kind: OnnxRuntimeErrorKind
+    /// Human-readable failure detail.
+    public let message: String
+    /// Optional underlying error description captured for telemetry details.
+    public let originalErrorDescription: String?
+
+    public init(kind: OnnxRuntimeErrorKind, message: String, originalError: Error? = nil) {
+        self.kind = kind
+        self.message = message
+        self.originalErrorDescription = originalError.map { String(describing: $0) }
+    }
+}
+
+/// Injectable seam between the IndeRun Apple ONNX provider and the actual on-device runtime.
+///
+/// IndeRun ships a default runtime backed by the official ONNX Runtime SPM bindings plus
+/// `swift-transformers` tokenization, and a deterministic fixture for tests and demos.
+/// Applications can supply their own implementation (for example one wrapping ONNX Runtime
+/// GenAI once it is SPM-installable, or a KV-cached decode loop) without touching the provider.
+public protocol OnnxGenAiRuntime: Sendable {
+    /// Checks runtime package availability, execution backend availability, and model readiness.
+    /// Implementations must resolve with an availability snapshot rather than throwing.
+    func prepare(_ modelPackage: ModelPackage) async -> OnnxRuntimeAvailability
+
+    /// Runs one Mode-1 generation.
+    func generate(_ input: OnnxGenerationInput) async throws -> OnnxGenerationOutput
+}

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxRuntimeAppleProvider.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxRuntimeAppleProvider.swift
@@ -1,0 +1,252 @@
+import Foundation
+import IndeRunContracts
+import IndeRunCore
+
+/// Task kind this provider implements in Milestone 2 (Mode 1 only).
+private let textToText = "text_to_text"
+
+/// Configuration for the Apple ONNX Runtime provider.
+public struct OnnxProviderOptions: Sendable {
+    /// Provider id exposed in telemetry and routing explanations.
+    public var id: String
+    /// Provider-neutral bootstrap metadata describing the developer-supplied model.
+    public var modelPackage: ModelPackage
+    /// Runtime implementation used to execute generation. Defaults to the ONNX Runtime SPM +
+    /// swift-transformers-backed runtime; applications can inject their own implementation of
+    /// the seam.
+    public var runtime: (any OnnxGenAiRuntime)?
+    /// Optional generation timeout. A request-level `constraints.timeoutMs` wins.
+    public var timeout: Duration?
+
+    public init(
+        id: String = OnnxRuntimeAppleProvider.defaultId,
+        modelPackage: ModelPackage,
+        runtime: (any OnnxGenAiRuntime)? = nil,
+        timeout: Duration? = nil
+    ) {
+        self.id = id
+        self.modelPackage = modelPackage
+        self.runtime = runtime
+        self.timeout = timeout
+    }
+}
+
+/// Local provider adapter that executes Mode-1 text-to-text requests with a developer-supplied
+/// ONNX model on Apple platforms.
+///
+/// The adapter owns the IndeRun-facing contract (descriptor, capability checks, error taxonomy)
+/// and delegates execution to an injectable `OnnxGenAiRuntime`. ONNX Runtime execution backends
+/// (CPU, CoreML, XNNPACK) stay behind that seam and are never public routing concepts.
+public final class OnnxRuntimeAppleProvider: ProviderAdapter, Sendable {
+    /// Default provider id of the Apple-platform member of the ONNX Runtime provider family.
+    public static let defaultId = "local.onnx.genai.apple"
+
+    /// Model source types the Apple member of the ONNX Runtime provider family can honor, per the
+    /// support matrix in `docs/architecture/onnx-runtime-provider-family.md`: `registry` and
+    /// `remote` are deferred everywhere at this stage; Apple additionally supports `filesystem`
+    /// (unlike Web, which cannot read arbitrary local paths).
+    public static let supportedModelSourceTypes: [SourceType] = [.bundled, .programmatic, .appManaged, .filesystem]
+
+    private let id: String
+    private let modelPackage: ModelPackage
+    private let runtime: any OnnxGenAiRuntime
+    private let timeout: Duration?
+
+    /// Creates an Apple ONNX Runtime provider.
+    /// - Parameter options: Model package plus optional id, runtime, and timeout overrides.
+    public init(options: OnnxProviderOptions) {
+        self.id = options.id
+        self.modelPackage = options.modelPackage
+        self.runtime = options.runtime ?? SystemOnnxGenAiRuntime()
+        self.timeout = options.timeout
+    }
+
+    /// Returns static metadata used by the router for deterministic provider selection.
+    public func describe() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: id,
+            type: .local,
+            transport: .inProcess,
+            supports: ProviderDescriptor.SupportsCapabilities(
+                run: true,
+                streaming: false,
+                realtime: false,
+                tools: false,
+                reasoningEvents: false,
+                structuredOutput: false,
+                multimodal: false
+            ),
+            cancel: .soft,
+            tasks: declaredTasks(modelPackage),
+            privacy: ProviderDescriptor.PrivacyDescriptor(dataLeavesDevice: false)
+        )
+    }
+
+    /// Reports dynamic provider availability for the current host.
+    ///
+    /// Every failure below is provider-internal detail: the shared route planner flattens it
+    /// into a single `capability_unavailable` rejection carrying the returned reason.
+    ///
+    /// - Parameter host: Host services available to the engine (unused; ONNX runs in-process).
+    public func capabilities(host: HostServices) async -> ProviderDynamicCapabilities {
+        let issues = getModelPackageValidationIssues(modelPackage)
+        if !issues.isEmpty {
+            let summary = issues.map { "\($0.path) \($0.message)" }.joined(separator: "; ")
+            return ProviderDynamicCapabilities(available: false, reason: "model package malformed: \(summary)")
+        }
+
+        if let sourceType = modelPackage.source?.sourceType, !Self.supportedModelSourceTypes.contains(sourceType) {
+            let supported = Self.supportedModelSourceTypes.map(\.rawValue).joined(separator: ", ")
+            let rawValue = sourceType.rawValue
+            let reason = sourceType == .registry || sourceType == .remote
+                ? "model source unavailable: '\(rawValue)' model sources are deferred on Apple platforms; "
+                    + "supply model files as \(supported)."
+                : "model source unavailable: '\(rawValue)' model sources are unsupported on Apple platforms."
+            return ProviderDynamicCapabilities(available: false, reason: reason)
+        }
+
+        if let platforms = modelPackage.runtime?.platforms, !platforms.isEmpty, !platforms.contains("apple") {
+            return ProviderDynamicCapabilities(
+                available: false,
+                reason: "platform unsupported: the model package targets \(platforms.joined(separator: ", ")) and does not list 'apple'."
+            )
+        }
+
+        let tasks = declaredTasks(modelPackage)
+        if !tasks.contains(textToText) {
+            let declared = tasks.joined(separator: ", ")
+            return ProviderDynamicCapabilities(
+                available: false,
+                reason: "unsupported task: the model package declares \(declared) and does not support '\(textToText)'."
+            )
+        }
+
+        let availability = await runtime.prepare(modelPackage)
+        return ProviderDynamicCapabilities(available: availability.available, reason: availability.reason)
+    }
+
+    /// Executes a normalized text-to-text task on the developer-supplied local ONNX model.
+    /// - Parameters:
+    ///   - request: Canonical IndeRun task request.
+    ///   - context: Engine execution context containing the run id and host services.
+    /// - Returns: A normalized IndeRun task result.
+    /// - Throws: `IndeRunException` mapped to the standard error taxonomy.
+    public func run(request: TaskRequest, context: RunContext) async throws -> TaskResult {
+        let availability = await capabilities(host: context.hostServices)
+        guard availability.available else {
+            throw createCapabilityMismatch(
+                message: availability.reason ?? "ONNX Runtime Apple provider is unavailable on this host.",
+                runId: context.runId,
+                providerId: id
+            )
+        }
+
+        let messages = createMessages(from: request)
+        guard !messages.isEmpty else {
+            throw createInternal(
+                message: "ONNX Runtime Apple provider requires a prompt or messages.",
+                runId: context.runId,
+                providerId: id
+            )
+        }
+
+        let effectiveTimeout = requestTimeout(from: request) ?? timeout
+        let output: OnnxGenerationOutput
+        do {
+            output = try await runWithTimeout(effectiveTimeout) {
+                try await self.runtime.generate(
+                    OnnxGenerationInput(modelPackage: self.modelPackage, messages: messages, generation: request.generation)
+                )
+            }
+        } catch {
+            throw mapRuntimeError(error, context: context)
+        }
+
+        guard !output.text.isEmpty else {
+            throw createInternal(
+                message: "ONNX Runtime Apple provider returned no text output.",
+                runId: context.runId,
+                providerId: id
+            )
+        }
+
+        return TaskResult(
+            runId: context.runId,
+            output: Output(text: output.text),
+            finishReason: output.finishReason ?? .stop,
+            usage: output.usage,
+            telemetry: TelemetryInfo(providerUsed: id, totalMs: 0)
+        )
+    }
+
+    private func mapRuntimeError(_ error: Error, context: RunContext) -> IndeRunException {
+        if let runtimeError = error as? OnnxRuntimeError {
+            var details: [String: JSONAny] = [:]
+            if let original = runtimeError.originalErrorDescription {
+                details["originalError"] = JSONAny(original)
+            }
+            let detailsArg = details.isEmpty ? nil : details
+
+            switch runtimeError.kind {
+            case .capability:
+                return createCapabilityMismatch(message: runtimeError.message, runId: context.runId, providerId: id, details: detailsArg)
+            case .unavailable:
+                return createUnavailable(message: runtimeError.message, runId: context.runId, providerId: id, details: detailsArg)
+            case .timeout:
+                return createTimeout(message: runtimeError.message, runId: context.runId, providerId: id, details: detailsArg)
+            case .internalFailure:
+                return createInternal(message: runtimeError.message, runId: context.runId, providerId: id, details: detailsArg)
+            }
+        }
+
+        if error is CancellationError {
+            return createTimeout(message: "ONNX Runtime Apple generation timed out or was cancelled.", runId: context.runId, providerId: id)
+        }
+
+        if let indeRunError = error as? IndeRunException {
+            return toIndeRunException(indeRunError, fallbackRunId: context.runId, fallbackProviderId: id)
+        }
+
+        return createInternal(
+            message: "ONNX Runtime Apple provider execution failed.",
+            runId: context.runId,
+            providerId: id,
+            details: ["originalError": JSONAny(String(describing: error))]
+        )
+    }
+}
+
+private func declaredTasks(_ modelPackage: ModelPackage) -> [String] {
+    guard let tasks = modelPackage.tasks, !tasks.isEmpty else { return [textToText] }
+    return tasks
+}
+
+private func createMessages(from request: TaskRequest) -> [OnnxGenerationMessage] {
+    if let messages = request.messages, !messages.isEmpty {
+        return messages.map { OnnxGenerationMessage(role: $0.role, content: $0.content) }
+    }
+
+    guard let prompt = request.prompt, !prompt.isEmpty else { return [] }
+    return [OnnxGenerationMessage(role: .user, content: prompt)]
+}
+
+private func requestTimeout(from request: TaskRequest) -> Duration? {
+    guard let timeoutMs = request.constraints?.timeoutMs, timeoutMs > 0 else { return nil }
+    return .milliseconds(timeoutMs)
+}
+
+private func runWithTimeout<T: Sendable>(_ timeout: Duration?, operation: @escaping @Sendable () async throws -> T) async throws -> T {
+    guard let timeout else { return try await operation() }
+
+    return try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw OnnxRuntimeError(kind: .timeout, message: "ONNX Runtime Apple generation timed out.")
+        }
+
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxRuntimeAppleProvider.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxRuntimeAppleProvider.swift
@@ -158,6 +158,11 @@ public final class OnnxRuntimeAppleProvider: ProviderAdapter, Sendable {
                     OnnxGenerationInput(modelPackage: self.modelPackage, messages: messages, generation: request.generation)
                 )
             }
+        } catch is CancellationError {
+            // Real Task cancellation propagates raw, uncaught, matching OpenAIProvider and
+            // IndeRun.swift -- it is not normalized into an IndeRunException. Only the explicit
+            // deadline branch in `runWithTimeout` below produces a `Timeout` IndeRunException.
+            throw CancellationError()
         } catch {
             throw mapRuntimeError(error, context: context)
         }
@@ -197,10 +202,6 @@ public final class OnnxRuntimeAppleProvider: ProviderAdapter, Sendable {
             case .internalFailure:
                 return createInternal(message: runtimeError.message, runId: context.runId, providerId: id, details: detailsArg)
             }
-        }
-
-        if error is CancellationError {
-            return createTimeout(message: "ONNX Runtime Apple generation timed out or was cancelled.", runId: context.runId, providerId: id)
         }
 
         if let indeRunError = error as? IndeRunException {

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
@@ -1,0 +1,264 @@
+import Foundation
+import IndeRunContracts
+import OnnxRuntimeBindings
+import Tokenizers
+
+/// Default production `OnnxGenAiRuntime`, backed by the official ONNX Runtime SPM bindings
+/// (`microsoft/onnxruntime-swift-package-manager`) for inference and `swift-transformers`'s
+/// `Tokenizers` module for tokenization.
+///
+/// **IO contract.** This runtime expects the model graph to expose exactly the inputs
+/// `input_ids` and `attention_mask` (both `int64`, shape `[1, sequenceLength]`) and a `logits`
+/// output (`float32`, shape `[1, sequenceLength, vocabSize]`) -- the plain decoder-only export
+/// shape, without `past_key_values`. Models exported with KV-cache inputs (the common
+/// Hugging Face Optimum convention) are not supported by this default runtime; supply a custom
+/// `OnnxGenAiRuntime` for those.
+///
+/// **Decode loop.** Generation is greedy (argmax) and recomputes the full sequence on every step
+/// -- there is no KV-cache reuse in this version. This is a known, documented performance
+/// limitation (see `docs/architecture/onnx-runtime-provider-family.md`), not a hidden one; apps
+/// that need throughput can inject a KV-cached runtime behind the same seam.
+///
+/// **Model sources.** `bundled` resolves under `Bundle.main.resourceURL`, `filesystem` and
+/// `app_managed` resolve `source.ref` as a directory path (absolute, or relative to the app's
+/// Application Support directory for `app_managed`). `programmatic` has no files to resolve and
+/// is reported as unavailable; apps using `programmatic` sources must supply their own runtime.
+public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
+    private static let defaultMaxOutputTokens = 256
+    private static let inputIdsName = "input_ids"
+    private static let attentionMaskName = "attention_mask"
+    private static let logitsName = "logits"
+
+    private let session: LoadedSessionBox
+
+    public init() {
+        self.session = LoadedSessionBox()
+    }
+
+    public func prepare(_ modelPackage: ModelPackage) async -> OnnxRuntimeAvailability {
+        do {
+            _ = try await session.loaded(for: modelPackage)
+            return OnnxRuntimeAvailability(available: true)
+        } catch let error as OnnxRuntimeError {
+            return OnnxRuntimeAvailability(available: false, reason: error.message)
+        } catch {
+            return OnnxRuntimeAvailability(available: false, reason: "runtime initialization failed: \(error).")
+        }
+    }
+
+    public func generate(_ input: OnnxGenerationInput) async throws -> OnnxGenerationOutput {
+        let loaded = try await session.loaded(for: input.modelPackage)
+        let prompt = normalizedPrompt(from: input.messages)
+        var tokenIds = loaded.tokenizer.encode(text: prompt)
+
+        guard !tokenIds.isEmpty else {
+            throw OnnxRuntimeError(kind: .capability, message: "model output malformed: tokenizer produced no input tokens.")
+        }
+
+        let maxOutputTokens = input.generation?.maxOutputTokens ?? Self.defaultMaxOutputTokens
+        let eosTokenId = loaded.tokenizer.eosTokenId
+        let promptLength = tokenIds.count
+        var generatedCount = 0
+
+        while generatedCount < maxOutputTokens {
+            try Task.checkCancellation()
+
+            let nextToken = try runStep(loaded: loaded, tokenIds: tokenIds)
+            tokenIds.append(nextToken)
+            generatedCount += 1
+
+            if let eosTokenId, nextToken == eosTokenId {
+                break
+            }
+        }
+
+        let generatedIds = Array(tokenIds[promptLength...])
+        let text = loaded.tokenizer.decode(tokens: generatedIds, skipSpecialTokens: true)
+        let finishReason: FinishReason = generatedCount >= maxOutputTokens ? .length : .stop
+
+        return OnnxGenerationOutput(
+            text: text,
+            finishReason: finishReason,
+            usage: Usage(inputTokens: promptLength, outputTokens: generatedCount, totalTokens: promptLength + generatedCount)
+        )
+    }
+
+    private func runStep(loaded: LoadedSession, tokenIds: [Int]) throws -> Int {
+        let sequenceLength = tokenIds.count
+
+        let tensorByteCount = sequenceLength * MemoryLayout<Int64>.size
+        let inputIdsData = NSMutableData(bytes: tokenIds.map { Int64($0) }, length: tensorByteCount)
+        let attentionMaskData = NSMutableData(bytes: [Int64](repeating: 1, count: sequenceLength), length: tensorByteCount)
+
+        do {
+            let inputIdsValue = try ORTValue(
+                tensorData: inputIdsData,
+                elementType: .int64,
+                shape: [1, NSNumber(value: sequenceLength)]
+            )
+            let attentionMaskValue = try ORTValue(
+                tensorData: attentionMaskData,
+                elementType: .int64,
+                shape: [1, NSNumber(value: sequenceLength)]
+            )
+
+            let outputs = try loaded.session.run(
+                withInputs: [Self.inputIdsName: inputIdsValue, Self.attentionMaskName: attentionMaskValue],
+                outputNames: [Self.logitsName],
+                runOptions: nil
+            )
+
+            guard let logitsValue = outputs[Self.logitsName] else {
+                throw OnnxRuntimeError(kind: .internalFailure, message: "model output malformed: missing '\(Self.logitsName)' output.")
+            }
+
+            return try argmaxLastPosition(logits: logitsValue, sequenceLength: sequenceLength)
+        } catch let error as OnnxRuntimeError {
+            throw error
+        } catch {
+            throw OnnxRuntimeError(kind: .unavailable, message: "ONNX Runtime session execution failed.", originalError: error)
+        }
+    }
+
+    private func argmaxLastPosition(logits: ORTValue, sequenceLength: Int) throws -> Int {
+        let typeAndShape = try logits.tensorTypeAndShapeInfo()
+        let shape = typeAndShape.shape.map { $0.intValue }
+        guard shape.count == 3, shape[0] == 1, shape[1] == sequenceLength else {
+            throw OnnxRuntimeError(kind: .internalFailure, message: "model output malformed: unexpected logits shape \(shape).")
+        }
+        let vocabSize = shape[2]
+
+        let data = try logits.tensorData()
+        let floats = (data as Data).withUnsafeBytes { pointer in
+            Array(pointer.bindMemory(to: Float.self))
+        }
+
+        let lastPositionOffset = (sequenceLength - 1) * vocabSize
+        guard floats.count >= lastPositionOffset + vocabSize else {
+            throw OnnxRuntimeError(kind: .internalFailure, message: "model output malformed: logits buffer smaller than expected shape.")
+        }
+
+        var bestIndex = 0
+        var bestValue = -Float.infinity
+        for index in 0..<vocabSize {
+            let value = floats[lastPositionOffset + index]
+            if value > bestValue {
+                bestValue = value
+                bestIndex = index
+            }
+        }
+        return bestIndex
+    }
+
+    private func normalizedPrompt(from messages: [OnnxGenerationMessage]) -> String {
+        messages.map { "\($0.role.rawValue): \($0.content)" }.joined(separator: "\n")
+    }
+}
+
+/// A tokenizer + ORT session resolved and loaded for a specific model package.
+///
+/// `@unchecked Sendable`: `ORTSession.run` is documented safe for concurrent invocation and this
+/// value only ever crosses from `LoadedSessionBox` (an actor) back to its single caller, mirroring
+/// the `@unchecked Sendable` pattern already used for actor-adjacent state elsewhere in this SDK.
+private struct LoadedSession: @unchecked Sendable {
+    let tokenizer: Tokenizer
+    let session: ORTSession
+}
+
+/// Lazily resolves and caches the loaded session for the most recently requested model package,
+/// so repeated `prepare`/`generate` calls do not reload the model and tokenizer every time.
+private actor LoadedSessionBox {
+    private var cached: (modelPackageId: String, loaded: LoadedSession)?
+
+    func loaded(for modelPackage: ModelPackage) async throws -> LoadedSession {
+        if let cached, cached.modelPackageId == modelPackage.id {
+            return cached.loaded
+        }
+
+        let loaded = try await Self.load(modelPackage)
+        cached = (modelPackage.id, loaded)
+        return loaded
+    }
+
+    private static func load(_ modelPackage: ModelPackage) async throws -> LoadedSession {
+        guard modelPackage.format == .onnx || modelPackage.format == .ort else {
+            let format = modelPackage.format.rawValue
+            throw OnnxRuntimeError(
+                kind: .capability,
+                message: "unsupported model format: SystemOnnxGenAiRuntime requires format 'onnx' or 'ort', got '\(format)'."
+            )
+        }
+
+        let directory = try resolveDirectory(modelPackage)
+
+        guard let requiredFiles = modelPackage.files?.filesRequired, let modelFileName = requiredFiles.first else {
+            throw OnnxRuntimeError(kind: .capability, message: "model files missing: model package declares no required files.")
+        }
+        let modelPath = directory.appendingPathComponent(modelFileName)
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw OnnxRuntimeError(kind: .capability, message: "model files missing: '\(modelFileName)' not found at \(modelPath.path).")
+        }
+
+        guard modelPackage.files?.tokenizer != nil else {
+            throw OnnxRuntimeError(kind: .capability, message: "tokenizer/config missing: model package declares no tokenizer file.")
+        }
+
+        let tokenizer: Tokenizer
+        do {
+            tokenizer = try await AutoTokenizer.from(modelFolder: directory)
+        } catch {
+            throw OnnxRuntimeError(kind: .capability, message: "tokenizer/config missing: failed to load tokenizer.", originalError: error)
+        }
+
+        let session: ORTSession
+        do {
+            let env = try ORTEnv(loggingLevel: .warning)
+            session = try ORTSession(env: env, modelPath: modelPath.path, sessionOptions: nil)
+        } catch {
+            throw OnnxRuntimeError(
+                kind: .unavailable,
+                message: "runtime initialization failed: unable to create ONNX Runtime session.",
+                originalError: error
+            )
+        }
+
+        return LoadedSession(tokenizer: tokenizer, session: session)
+    }
+
+    private static func resolveDirectory(_ modelPackage: ModelPackage) throws -> URL {
+        guard let source = modelPackage.source else {
+            throw OnnxRuntimeError(kind: .capability, message: "model source unavailable: model package declares no source.")
+        }
+
+        switch source.sourceType {
+        case .bundled:
+            guard let resourceURL = Bundle.main.resourceURL else {
+                throw OnnxRuntimeError(kind: .unavailable, message: "runtime initialization failed: app bundle has no resource directory.")
+            }
+            return source.ref.map { resourceURL.appendingPathComponent($0) } ?? resourceURL
+        case .filesystem:
+            guard let ref = source.ref else {
+                throw OnnxRuntimeError(kind: .capability, message: "model source unavailable: 'filesystem' source requires 'ref'.")
+            }
+            return URL(fileURLWithPath: ref)
+        case .appManaged:
+            let base = try FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: false
+            )
+            return source.ref.map { base.appendingPathComponent($0) } ?? base
+        case .programmatic:
+            throw OnnxRuntimeError(
+                kind: .capability,
+                message: "model source unavailable: 'programmatic' sources require an application-supplied OnnxGenAiRuntime."
+            )
+        case .registry, .remote:
+            throw OnnxRuntimeError(
+                kind: .capability,
+                message: "model source unavailable: '\(source.sourceType.rawValue)' model sources are deferred on Apple platforms."
+            )
+        }
+    }
+}

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import IndeRunContracts
 import OnnxRuntimeBindings
@@ -15,9 +16,17 @@ import Tokenizers
 /// `OnnxGenAiRuntime` for those.
 ///
 /// **Decode loop.** Generation is greedy (argmax) and recomputes the full sequence on every step
-/// -- there is no KV-cache reuse in this version. This is a known, documented performance
-/// limitation (see `docs/architecture/onnx-runtime-provider-family.md`), not a hidden one; apps
-/// that need throughput can inject a KV-cached runtime behind the same seam.
+/// -- there is no KV-cache reuse, no CoreML execution provider, and no shared/tuned `ORTEnv` or
+/// thread-pool policy in this version. This is a known, documented performance limitation (see
+/// `docs/architecture/onnx-runtime-provider-family.md`), not a hidden one -- CPU-only, unoptimized
+/// throughput. `generation.stop` sequences are honored; `temperature`/`topP`/`seed` are not (there
+/// is no sampling, only argmax). Apps that need throughput, sampling, or an accelerated execution
+/// provider inject a different runtime behind the same seam.
+///
+/// **Chat formatting.** Input is tokenized via the tokenizer's chat template
+/// (`Tokenizer.applyChatTemplate`) when the loaded `tokenizer_config.json` declares one, since most
+/// instruction-tuned models require their specific role-tagged special tokens. Tokenizers without a
+/// configured template fall back to a plain `"role: content"` join.
 ///
 /// **Model sources.** `bundled` resolves under `Bundle.main.resourceURL`, `filesystem` and
 /// `app_managed` resolve `source.ref` as a directory path (absolute, or relative to the app's
@@ -48,17 +57,18 @@ public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
 
     public func generate(_ input: OnnxGenerationInput) async throws -> OnnxGenerationOutput {
         let loaded = try await session.loaded(for: input.modelPackage)
-        let prompt = normalizedPrompt(from: input.messages)
-        var tokenIds = loaded.tokenizer.encode(text: prompt)
+        var tokenIds = encodeInput(input.messages, tokenizer: loaded.tokenizer)
 
         guard !tokenIds.isEmpty else {
             throw OnnxRuntimeError(kind: .capability, message: "model output malformed: tokenizer produced no input tokens.")
         }
 
         let maxOutputTokens = input.generation?.maxOutputTokens ?? Self.defaultMaxOutputTokens
+        let stopSequences = (input.generation?.stop ?? []).filter { !$0.isEmpty }
         let eosTokenId = loaded.tokenizer.eosTokenId
         let promptLength = tokenIds.count
         var generatedCount = 0
+        var matchedStop: String?
 
         while generatedCount < maxOutputTokens {
             try Task.checkCancellation()
@@ -70,10 +80,21 @@ public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
             if let eosTokenId, nextToken == eosTokenId {
                 break
             }
+
+            if !stopSequences.isEmpty {
+                let partialText = loaded.tokenizer.decode(tokens: Array(tokenIds[promptLength...]), skipSpecialTokens: true)
+                if let stop = stopSequences.first(where: { partialText.hasSuffix($0) }) {
+                    matchedStop = stop
+                    break
+                }
+            }
         }
 
         let generatedIds = Array(tokenIds[promptLength...])
-        let text = loaded.tokenizer.decode(tokens: generatedIds, skipSpecialTokens: true)
+        var text = loaded.tokenizer.decode(tokens: generatedIds, skipSpecialTokens: true)
+        if let matchedStop, text.hasSuffix(matchedStop) {
+            text.removeLast(matchedStop.count)
+        }
         let finishReason: FinishReason = generatedCount >= maxOutputTokens ? .length : .stop
 
         return OnnxGenerationOutput(
@@ -81,6 +102,17 @@ public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
             finishReason: finishReason,
             usage: Usage(inputTokens: promptLength, outputTokens: generatedCount, totalTokens: promptLength + generatedCount)
         )
+    }
+
+    /// Tokenizes input via the model's chat template when the tokenizer provides one (correct for
+    /// instruction-tuned models, which expect role-tagged special tokens rather than plain text),
+    /// falling back to a plain `role: content` join for tokenizers without a configured template.
+    private func encodeInput(_ messages: [OnnxGenerationMessage], tokenizer: Tokenizer) -> [Int] {
+        let chatMessages: [[String: any Sendable]] = messages.map { ["role": $0.role.rawValue, "content": $0.content] }
+        if let tokenIds = try? tokenizer.applyChatTemplate(messages: chatMessages) {
+            return tokenIds
+        }
+        return tokenizer.encode(text: normalizedPrompt(from: messages))
     }
 
     private func runStep(loaded: LoadedSession, tokenIds: [Int]) throws -> Int {
@@ -128,23 +160,27 @@ public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
         }
         let vocabSize = shape[2]
 
+        // Reads only the final position's row directly out of the tensor buffer rather than
+        // copying the full [sequenceLength x vocabSize] tensor into a Swift Array -- the decode
+        // loop only ever needs the last row's argmax.
         let data = try logits.tensorData()
-        let floats = (data as Data).withUnsafeBytes { pointer in
-            Array(pointer.bindMemory(to: Float.self))
-        }
-
         let lastPositionOffset = (sequenceLength - 1) * vocabSize
-        guard floats.count >= lastPositionOffset + vocabSize else {
+        let byteOffset = lastPositionOffset * MemoryLayout<Float>.size
+        let rowByteCount = vocabSize * MemoryLayout<Float>.size
+        guard data.length >= byteOffset + rowByteCount else {
             throw OnnxRuntimeError(kind: .internalFailure, message: "model output malformed: logits buffer smaller than expected shape.")
         }
 
         var bestIndex = 0
         var bestValue = -Float.infinity
-        for index in 0..<vocabSize {
-            let value = floats[lastPositionOffset + index]
-            if value > bestValue {
-                bestValue = value
-                bestIndex = index
+        (data as Data).withUnsafeBytes { (rawPointer: UnsafeRawBufferPointer) in
+            let lastRow = rawPointer.baseAddress!.advanced(by: byteOffset).assumingMemoryBound(to: Float.self)
+            for index in 0..<vocabSize {
+                let value = lastRow[index]
+                if value > bestValue {
+                    bestValue = value
+                    bestIndex = index
+                }
             }
         }
         return bestIndex
@@ -168,16 +204,33 @@ private struct LoadedSession: @unchecked Sendable {
 /// Lazily resolves and caches the loaded session for the most recently requested model package,
 /// so repeated `prepare`/`generate` calls do not reload the model and tokenizer every time.
 private actor LoadedSessionBox {
-    private var cached: (modelPackageId: String, loaded: LoadedSession)?
+    private var cached: (key: String, loaded: LoadedSession)?
 
     func loaded(for modelPackage: ModelPackage) async throws -> LoadedSession {
-        if let cached, cached.modelPackageId == modelPackage.id {
+        let key = Self.cacheKey(for: modelPackage)
+        if let cached, cached.key == key {
             return cached.loaded
         }
 
         let loaded = try await Self.load(modelPackage)
-        cached = (modelPackage.id, loaded)
+        cached = (key, loaded)
         return loaded
+    }
+
+    /// Cache key covering everything that identifies *which bytes* this session was built from --
+    /// `id` alone does not: an app can swap a bundled model file, change `source.ref`, or bump
+    /// `version` while keeping the same `id`, and a stale cached session would silently keep
+    /// serving the old model.
+    private static func cacheKey(for modelPackage: ModelPackage) -> String {
+        var parts = [modelPackage.id, modelPackage.format.rawValue, modelPackage.version ?? ""]
+        if let source = modelPackage.source {
+            parts.append(source.sourceType.rawValue)
+            parts.append(source.ref ?? "")
+        }
+        if let checksums = modelPackage.integrity?.checksums {
+            parts.append(checksums.sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" }.joined(separator: ","))
+        }
+        return parts.joined(separator: "|")
     }
 
     private static func load(_ modelPackage: ModelPackage) async throws -> LoadedSession {
@@ -191,6 +244,12 @@ private actor LoadedSessionBox {
 
         let directory = try resolveDirectory(modelPackage)
 
+        // Graph file convention: the schema's `files.required` has no positional/role semantics
+        // of its own, so this runtime defines one explicitly -- the *first* entry is the ONNX
+        // graph file; any remaining entries (for example external weight shards) are required to
+        // be present but are not referenced directly, since ORT resolves them relative to the
+        // graph file itself. This convention is documented in
+        // `docs/architecture/onnx-runtime-provider-family.md#apple-implementation`.
         guard let requiredFiles = modelPackage.files?.filesRequired, let modelFileName = requiredFiles.first else {
             throw OnnxRuntimeError(kind: .capability, message: "model files missing: model package declares no required files.")
         }
@@ -198,10 +257,24 @@ private actor LoadedSessionBox {
         guard FileManager.default.fileExists(atPath: modelPath.path) else {
             throw OnnxRuntimeError(kind: .capability, message: "model files missing: '\(modelFileName)' not found at \(modelPath.path).")
         }
+        for fileName in requiredFiles.dropFirst() {
+            guard FileManager.default.fileExists(atPath: directory.appendingPathComponent(fileName).path) else {
+                throw OnnxRuntimeError(kind: .capability, message: "model files missing: '\(fileName)' not found in \(directory.path).")
+            }
+        }
 
-        guard modelPackage.files?.tokenizer != nil else {
+        guard let tokenizerFileName = modelPackage.files?.tokenizer else {
             throw OnnxRuntimeError(kind: .capability, message: "tokenizer/config missing: model package declares no tokenizer file.")
         }
+        let tokenizerPath = directory.appendingPathComponent(tokenizerFileName)
+        guard FileManager.default.fileExists(atPath: tokenizerPath.path) else {
+            throw OnnxRuntimeError(
+                kind: .capability,
+                message: "tokenizer/config missing: '\(tokenizerFileName)' not found at \(tokenizerPath.path)."
+            )
+        }
+
+        try verifyChecksums(modelPackage, directory: directory)
 
         let tokenizer: Tokenizer
         do {
@@ -223,6 +296,47 @@ private actor LoadedSessionBox {
         }
 
         return LoadedSession(tokenizer: tokenizer, session: session)
+    }
+
+    /// Verifies `ModelPackage.integrity.checksums` (`sha256:<hex>`) for every declared file this
+    /// runtime actually resolved a path for, before the graph or tokenizer is loaded. Declared
+    /// checksums for files outside this runtime's resolution (for example files a different
+    /// runtime seam would use) are not checked -- only files under `directory` are addressable.
+    private static func verifyChecksums(_ modelPackage: ModelPackage, directory: URL) throws {
+        guard let checksums = modelPackage.integrity?.checksums, !checksums.isEmpty else { return }
+
+        for (fileName, expected) in checksums {
+            let fileURL = directory.appendingPathComponent(fileName)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else { continue }
+
+            let parts = expected.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2, parts[0] == "sha256" else {
+                throw OnnxRuntimeError(
+                    kind: .capability,
+                    message: "checksum/integrity mismatch: unsupported algorithm for '\(fileName)' (only 'sha256:<hex>' is supported)."
+                )
+            }
+            let expectedHex = String(parts[1])
+
+            let data: Data
+            do {
+                data = try Data(contentsOf: fileURL)
+            } catch {
+                throw OnnxRuntimeError(
+                    kind: .capability,
+                    message: "model files missing: unable to read '\(fileName)' for checksum verification.",
+                    originalError: error
+                )
+            }
+            let actualHex = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+
+            guard actualHex.caseInsensitiveCompare(expectedHex) == .orderedSame else {
+                throw OnnxRuntimeError(
+                    kind: .capability,
+                    message: "checksum/integrity mismatch: '\(fileName)' does not match its declared checksum."
+                )
+            }
+        }
     }
 
     private static func resolveDirectory(_ modelPackage: ModelPackage) throws -> URL {

--- a/ios/IndeRun/Tests/IndeRunTests/IndeRunTests.swift
+++ b/ios/IndeRun/Tests/IndeRunTests/IndeRunTests.swift
@@ -3,6 +3,7 @@ import IndeRunContracts
 @testable import IndeRunCore
 @testable import IndeRunAppleProviders
 @testable import IndeRunOpenAIProviders
+@testable import IndeRunOnnxProviders
 @testable import IndeRunSwift
 
 // MARK: - Mocks for Testing
@@ -789,5 +790,181 @@ final class IndeRunTests: XCTestCase {
 
         XCTAssertNotNil(registry.get(id: "openai"))
         XCTAssertEqual(registry.list().count, 1)
+    }
+
+    // MARK: - ONNX Runtime Apple provider
+
+    private func makeOnnxModelPackage(sourceType: SourceType = .bundled) -> ModelPackage {
+        ModelPackage(
+            files: Files(config: nil, external: nil, filesRequired: ["model.onnx"], tokenizer: "tokenizer.json"),
+            format: .onnx,
+            id: "test-model",
+            integrity: nil,
+            license: nil,
+            limits: nil,
+            runtime: nil,
+            source: Source(ref: "models/test-model", sourceType: sourceType),
+            tasks: ["text_to_text"],
+            version: "1.0"
+        )
+    }
+
+    func testOnnxAppleDescriptor() {
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: makeOnnxModelPackage(), runtime: createFixtureOnnxRuntime())
+        )
+        let descriptor = provider.describe()
+
+        XCTAssertEqual(descriptor.id, OnnxRuntimeAppleProvider.defaultId)
+        XCTAssertEqual(descriptor.type, .local)
+        XCTAssertEqual(descriptor.transport, .inProcess)
+        XCTAssertTrue(descriptor.supports.run)
+        XCTAssertFalse(descriptor.supports.streaming)
+        XCTAssertEqual(descriptor.cancel, .soft)
+        XCTAssertEqual(descriptor.tasks, ["text_to_text"])
+        XCTAssertEqual(descriptor.privacy?.dataLeavesDevice, false)
+    }
+
+    func testOnnxAppleCapabilitiesRejectsMalformedModelPackage() async {
+        let modelPackage = ModelPackage(
+            files: nil, format: .onnx, id: "", integrity: nil, license: nil, limits: nil,
+            runtime: nil, source: nil, tasks: nil, version: nil
+        )
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: modelPackage, runtime: createFixtureOnnxRuntime())
+        )
+
+        let capabilities = await provider.capabilities(host: hostServices)
+
+        XCTAssertFalse(capabilities.available)
+        XCTAssertTrue(capabilities.reason?.contains("model package malformed") ?? false)
+    }
+
+    func testOnnxAppleCapabilitiesRejectsDeferredSourceTypes() async {
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(
+                modelPackage: makeOnnxModelPackage(sourceType: .registry),
+                runtime: createFixtureOnnxRuntime()
+            )
+        )
+
+        let capabilities = await provider.capabilities(host: hostServices)
+
+        XCTAssertFalse(capabilities.available)
+        XCTAssertTrue(capabilities.reason?.contains("registry") ?? false)
+    }
+
+    func testOnnxAppleCapabilitiesAcceptsFilesystemSource() async {
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(
+                modelPackage: makeOnnxModelPackage(sourceType: .filesystem),
+                runtime: createFixtureOnnxRuntime()
+            )
+        )
+
+        let capabilities = await provider.capabilities(host: hostServices)
+
+        XCTAssertTrue(capabilities.available)
+    }
+
+    func testOnnxAppleCapabilitiesRejectsUnsupportedTask() async {
+        var modelPackage = makeOnnxModelPackage()
+        modelPackage.tasks = ["image_to_text"]
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: modelPackage, runtime: createFixtureOnnxRuntime())
+        )
+
+        let capabilities = await provider.capabilities(host: hostServices)
+
+        XCTAssertFalse(capabilities.available)
+        XCTAssertTrue(capabilities.reason?.contains("unsupported task") ?? false)
+    }
+
+    func testOnnxAppleRunReturnsTaskResultFromFixture() async throws {
+        let runtime = createFixtureOnnxRuntime(
+            options: FixtureOnnxRuntimeOptions(respond: { input in
+                OnnxGenerationOutput(text: "Bonjour, \(input.messages.last?.content ?? "")")
+            })
+        )
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: makeOnnxModelPackage(), runtime: runtime)
+        )
+        let request = TaskRequest(prompt: "world")
+
+        let result = try await provider.run(
+            request: request,
+            context: RunContext(runId: "run_onnx_apple", hostServices: hostServices)
+        )
+
+        XCTAssertEqual(result.runId, "run_onnx_apple")
+        XCTAssertEqual(result.output.text, "Bonjour, world")
+        XCTAssertEqual(result.finishReason, .stop)
+        XCTAssertEqual(result.telemetry.providerUsed, OnnxRuntimeAppleProvider.defaultId)
+    }
+
+    func testOnnxAppleRunThrowsCapabilityMismatchWhenUnavailable() async {
+        let runtime = createFixtureOnnxRuntime(
+            options: FixtureOnnxRuntimeOptions(availability: OnnxRuntimeAvailability(available: false, reason: "model files missing"))
+        )
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: makeOnnxModelPackage(), runtime: runtime)
+        )
+        let request = TaskRequest(prompt: "Hello")
+
+        do {
+            _ = try await provider.run(request: request, context: RunContext(runId: "run_unavailable", hostServices: hostServices))
+            XCTFail("Should have thrown CapabilityMismatch")
+        } catch let err as IndeRunException {
+            XCTAssertEqual(err.errorClass, .CapabilityMismatch)
+            XCTAssertEqual(err.providerId, OnnxRuntimeAppleProvider.defaultId)
+        } catch {
+            XCTFail("Expected IndeRunException")
+        }
+    }
+
+    func testOnnxAppleRunMapsRuntimeErrorKindsToErrorClasses() async {
+        let cases: [(OnnxRuntimeErrorKind, IndeRunErrorClass)] = [
+            (.capability, .CapabilityMismatch),
+            (.unavailable, .Unavailable),
+            (.timeout, .Timeout),
+            (.internalFailure, .Internal)
+        ]
+
+        for (kind, expectedClass) in cases {
+            let runtime = createFixtureOnnxRuntime(
+                options: FixtureOnnxRuntimeOptions(failWith: OnnxRuntimeError(kind: kind, message: "runtime failure"))
+            )
+            let provider = OnnxRuntimeAppleProvider(
+                options: OnnxProviderOptions(modelPackage: makeOnnxModelPackage(), runtime: runtime)
+            )
+            let request = TaskRequest(prompt: "Hello")
+
+            do {
+                _ = try await provider.run(request: request, context: RunContext(runId: "run_error", hostServices: hostServices))
+                XCTFail("Should have thrown for kind \(kind)")
+            } catch let err as IndeRunException {
+                XCTAssertEqual(err.errorClass, expectedClass)
+            } catch {
+                XCTFail("Expected IndeRunException for kind \(kind)")
+            }
+        }
+    }
+
+    func testOnnxAppleModelPackageValidationRejectsUrlUserinfoInSourceRef() {
+        var modelPackage = makeOnnxModelPackage()
+        modelPackage.source = Source(ref: "https://user:pass@example.com/model", sourceType: .bundled)
+
+        let issues = getModelPackageValidationIssues(modelPackage)
+
+        XCTAssertTrue(issues.contains { $0.path == "/source/ref" })
+    }
+
+    func testOnnxAppleModelPackageValidationAllowsPlainUrlInSourceRef() {
+        var modelPackage = makeOnnxModelPackage()
+        modelPackage.source = Source(ref: "https://example.com/model", sourceType: .bundled)
+
+        let issues = getModelPackageValidationIssues(modelPackage)
+
+        XCTAssertTrue(issues.isEmpty)
     }
 }

--- a/ios/IndeRun/Tests/IndeRunTests/IndeRunTests.swift
+++ b/ios/IndeRun/Tests/IndeRunTests/IndeRunTests.swift
@@ -967,4 +967,43 @@ final class IndeRunTests: XCTestCase {
 
         XCTAssertTrue(issues.isEmpty)
     }
+
+    func testOnnxAppleRunThrowsRawCancellationErrorWithoutNormalizing() async {
+        let runtime = createFixtureOnnxRuntime(options: FixtureOnnxRuntimeOptions(delay: .seconds(10)))
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: makeOnnxModelPackage(), runtime: runtime)
+        )
+        let request = TaskRequest(prompt: "Hello")
+
+        let runTask = Task {
+            try await provider.run(request: request, context: RunContext(runId: "run_cancel", hostServices: hostServices))
+        }
+        runTask.cancel()
+
+        do {
+            _ = try await runTask.value
+            XCTFail("Should have thrown CancellationError")
+        } catch is CancellationError {
+            // expected: real Task cancellation propagates raw, matching OpenAIProvider/IndeRun.swift
+        } catch {
+            XCTFail("Expected raw CancellationError, got \(error)")
+        }
+    }
+
+    func testOnnxAppleRunThrowsTimeoutWhenGenerationExceedsDeadline() async {
+        let runtime = createFixtureOnnxRuntime(options: FixtureOnnxRuntimeOptions(delay: .seconds(10)))
+        let provider = OnnxRuntimeAppleProvider(
+            options: OnnxProviderOptions(modelPackage: makeOnnxModelPackage(), runtime: runtime, timeout: .milliseconds(50))
+        )
+        let request = TaskRequest(prompt: "Hello")
+
+        do {
+            _ = try await provider.run(request: request, context: RunContext(runId: "run_timeout", hostServices: hostServices))
+            XCTFail("Should have thrown Timeout")
+        } catch let err as IndeRunException {
+            XCTAssertEqual(err.errorClass, .Timeout)
+        } catch {
+            XCTFail("Expected IndeRunException, got \(error)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Implements the Apple-platform member of the ONNX Runtime provider family (#86), per the family spec landed in #32.
- New `IndeRunOnnxProviders` SwiftPM target: `local.onnx.genai.apple` provider, injectable `OnnxGenAiRuntime` seam, public deterministic fixture, and a default `SystemOnnxGenAiRuntime` (official ORT SPM bindings + `swift-transformers` tokenization/chat-template, greedy decode with `generation.stop` support, checksum-verified/cache-correct model loading).
- Raises SDK platform minimums iOS 15→16 / macOS 12→14 (forced by the new dependencies; SwiftPM has no per-target override). Documented in `providers.md`, the ONNX spec, and both READMEs.
- Docs updated in the same task: `onnx-runtime-provider-family.md` (Apple Implementation section), `providers.md` (matrix), `ios/IndeRun/README.md`, root `README.md`.

**WIP** — draft; not merge-ready.

## Review response

Addressed from the first review pass:
- Cancellation now propagates as raw `CancellationError` instead of being normalized to `Timeout`, matching the established `OpenAIProvider`/`IndeRun.swift` convention (was mistakenly mirroring the Web TS provider's `AbortError→Timeout` pattern instead).
- `ModelPackage.integrity.checksums` are now verified before load; session cache key widened from `id` alone to `id`+`version`+`source`+checksums.
- Chat template (`Tokenizer.applyChatTemplate`) used when the tokenizer declares one, instead of always hand-joining `"role: content"`.
- `generation.stop` sequences honored in the decode loop.
- Logits read directly from the tensor buffer for just the last position instead of copying the full `[sequenceLength × vocabSize]` tensor.
- The previously-implicit "first `files.required` entry is the graph file" convention is now named and documented.

Explicitly deferred, not silently dropped:
- Runtime-lifecycle hardening (CoreML execution provider, shared `ORTEnv`, thread-pool policy, buffer reuse, KV-cache reuse, sampling) — tracked in #126.
- Real-device verification (load time, token latency, peak memory, cancellation behavior against a genuinely blocking `ORTSession.run()`, repeated-run stability) with an actual model/tokenizer — tracked in #88. This default runtime has not yet run against a real model on-device.

## Test plan
- [x] `swift build`
- [x] `swift test` (41/41 passing, incl. new cancellation/timeout tests against the fixture runtime)
- [x] `swiftlint lint --strict`
- [ ] Real-device verification with an actual ONNX model — tracked in #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)