### PR TITLE
chore(ci): ignore vendored .build/ paths in CodeQL scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       packages: read
       actions: read
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout-minutes || 30 }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +39,10 @@ jobs:
             build-mode: manual
           - language: swift
             build-mode: manual
+            # swift build pulls in onnxruntime-swift-package-manager (large prebuilt
+            # XCFramework) plus swift-huggingface/swift-transformers/swift-nio/swift-crypto
+            # -- a cold build can exceed the default 30min job timeout.
+            timeout-minutes: 60
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,6 +93,19 @@ jobs:
         if: matrix.language == 'java-kotlin'
         working-directory: android
         run: ./gradlew assembleDebug
+
+      # Cache SwiftPM checkouts/build artifacts (repo-root .build) keyed on
+      # Package.resolved so unchanged dependencies (onnxruntime-swift-package-manager's
+      # XCFramework, swift-huggingface, swift-transformers, swift-nio, ...) aren't
+      # re-fetched/re-built on every run.
+      - name: Cache SwiftPM dependencies
+        if: matrix.language == 'swift'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .build
+          key: swiftpm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-
 
       # Fast manual Swift build of the SwiftPM library targets, replacing the
       # autobuilder (which picks the ios/SampleApps demo xcodeproj and fails).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          # .build/ holds SwiftPM checkouts (e.g. swift-huggingface) -- vendored
+          # dependency source we don't control, not our code to fix findings in.
+          config: |
+            paths-ignore:
+              - '.build/**'
 
       # Explicit Gradle build of all Android modules (debug variant, no release
       # signing, tests skipped), instead of letting autobuild guess a target.

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -58,7 +58,18 @@ factories), not in prose.
     [Apple Implementation](onnx-runtime-provider-family.md#apple-implementation)). Demonstrated
     alongside Apple Foundation Models and the OpenAI-compatible cloud provider, routed by
     `checkCapabilities()` and a `Privacy`-preference selector, in the iOS sample app
-    (`ios/SampleApps/IndeRunDemo`).
+    (`ios/SampleApps/IndeRunDemo`). Depends transitively on `swift-huggingface` (via
+    `swift-transformers`' `Tokenizers`) for `AutoTokenizer.from(modelFolder:)`, used only to
+    load tokenizer config from an already-resolved local directory with hardcoded literal
+    filenames (`config.json`, `tokenizer.json`, ...) — no Hub network/download/cache APIs
+    (`HubApi.snapshot(from:)`, `.from(pretrained:)`, `HubCache`/`HubClient`) are called today.
+    Those Hub-network/cache-path APIs have open CodeQL `swift/path-injection` findings
+    upstream (`HubCache.cachedFilePath` builds cache paths from `revision`/`filename` without
+    the same validation `storeFile`/`storeData` apply; tracked in
+    huggingface/swift-huggingface#62). Before any
+    future code calls those APIs with a repo ID or filename that isn't a hardcoded literal,
+    check whether that issue is resolved, and if not, validate repo-id/filename inputs at the
+    call site.
   - Android on-device: `local.onnx.genai.android`, shipped in the `inderun-onnx-providers` Gradle
     module (see [Android Implementation](onnx-runtime-provider-family.md#android-implementation)).
     Demonstrated alongside Android ML Kit GenAI and the OpenAI-compatible cloud provider, routed


### PR DESCRIPTION
## Summary
- CodeQL was flagging 11 `swift/path-injection` alerts inside the vendored `swift-huggingface` SwiftPM checkout under `.build/` — code we don't own or control. Added `paths-ignore: ['.build/**']` to the CodeQL `init` step.
- Documented our current (safe) `swift-huggingface` usage in `docs/architecture/providers.md` and linked the upstream path-traversal issue filed for the one real gap found while triaging the alerts: huggingface/swift-huggingface#62

## Test plan
- [ ] CI CodeQL run on this PR no longer reports `.build/checkouts/**` findings
- [ ] Docs render correctly (`docs/architecture/providers.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)