### PR TITLE
feat(android): harden ONNX runtime (NNAPI/XNNPACK EP, shared env, KV-cache, sampling)

### DIFF
--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxDecoders.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxDecoders.kt
@@ -1,0 +1,181 @@
+package app.independo.inderun.providers.onnx
+
+import ai.onnxruntime.OnnxTensor
+import ai.onnxruntime.OnnxTensorLike
+import ai.onnxruntime.OrtSession
+import kotlinx.coroutines.withContext
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.LongBuffer
+
+/**
+ * IO tensor names shared by both decode paths and the KV-cache detection logic.
+ */
+private const val INPUT_IDS = "input_ids"
+private const val ATTENTION_MASK = "attention_mask"
+private const val POSITION_IDS = "position_ids"
+private const val LOGITS = "logits"
+private const val PAST_KEY_VALUES_PREFIX = "past_key_values."
+
+/** One decode step: produce a single generated token id given the tokens fed so far. */
+internal interface StepDecoder {
+    suspend fun step(sampling: SamplingConfig): Long
+}
+
+/**
+ * Full-sequence-recompute decode step: the plain `input_ids`/`attention_mask`/`logits` IO
+ * contract, without KV-cache reuse. Input buffers are preallocated once for the whole generation
+ * (sized to `promptLength + maxOutputTokens`, as direct buffers so ORT can reference them without
+ * an extra native copy) and written into a growing subrange each step, so only the token-id list
+ * grows -- no fresh buffer allocation per token. The `OnnxTensor`/`OrtSession.Result` objects
+ * themselves are still recreated every step: the sequence-length axis of their shape changes each
+ * step, so the tensor object (not its backing memory) cannot be reused across steps.
+ */
+internal class FullRecomputeDecoder(
+    private val loaded: LoadedSession,
+    promptTokenIds: List<Long>,
+    maxOutputTokens: Int,
+) : StepDecoder {
+    private val tokenIds = promptTokenIds.toMutableList()
+    private val capacity = promptTokenIds.size + maxOutputTokens
+    private val inputIdsBuffer = directLongBuffer(capacity)
+    private val attentionMaskBuffer = directLongBuffer(capacity)
+
+    override suspend fun step(sampling: SamplingConfig): Long {
+        val sequenceLength = tokenIds.size
+        for (index in 0 until sequenceLength) {
+            inputIdsBuffer.put(index, tokenIds[index])
+            attentionMaskBuffer.put(index, 1L)
+        }
+        val shape = longArrayOf(1, sequenceLength.toLong())
+
+        val nextToken = withContext(OnnxExecutionDispatcher.dispatcher) {
+            OnnxTensor.createTensor(loaded.environment, sliceView(inputIdsBuffer, sequenceLength), shape).use { inputIdsTensor ->
+                OnnxTensor.createTensor(loaded.environment, sliceView(attentionMaskBuffer, sequenceLength), shape).use { attentionMaskTensor ->
+                    val inputs = mapOf<String, OnnxTensorLike>(INPUT_IDS to inputIdsTensor, ATTENTION_MASK to attentionMaskTensor)
+                    runOnnxSession(loaded.session, inputs, setOf(LOGITS)).use { result ->
+                        val logitsTensor = requireOutput(result, LOGITS)
+                        selectNextToken(logitsTensor, sequenceLength, sampling)
+                    }
+                }
+            }
+        }
+
+        tokenIds += nextToken
+        return nextToken
+    }
+
+    private fun sliceView(source: LongBuffer, length: Int): LongBuffer {
+        val view = source.duplicate()
+        view.position(0)
+        view.limit(length)
+        return view.slice()
+    }
+}
+
+/**
+ * KV-cache decode step, following the legacy (non-merged) Hugging Face Optimum
+ * `decoder_with_past_model` export convention: exactly one token is fed as `input_ids` per model
+ * call (this graph's sequence-length axis is traced fixed at 1), with each call's `present.*`
+ * outputs threaded back in as the next call's `past_key_values.*` inputs directly (no copy) --
+ * itself the buffer-reuse win for this path, mirroring the Apple member's `KvCacheDecoder`.
+ */
+internal class KvCacheDecoder(
+    private val loaded: LoadedSession,
+    private val layout: KvCacheLayout,
+    promptTokenIds: List<Long>,
+) : StepDecoder {
+    private val tokenIds = promptTokenIds.toMutableList()
+    private var pastKeyValues: Map<String, OnnxTensor> = layout.emptyPastKeyValues(loaded.environment)
+
+    /**
+     * Prompt tokens not yet fed to the model. This graph traces `input_ids` with a
+     * sequence-length axis fixed at 1 -- there is no separate no-past graph to prefill the prompt
+     * in one call -- so the prompt must be replayed through the same with-past session one token
+     * at a time to build up `past_key_values` before generation can begin.
+     */
+    private val remainingPromptTokens = ArrayDeque(promptTokenIds)
+
+    /** Number of tokens already fed into the model (== the current `past_key_values` length). */
+    private var fedCount = 0
+
+    override suspend fun step(sampling: SamplingConfig): Long {
+        // Replay every remaining prompt token except the last, discarding logits -- only the
+        // last prompt token's logits (fed with every earlier token already in `past_key_values`)
+        // predict the first generated token.
+        while (remainingPromptTokens.size > 1) {
+            feedToken(remainingPromptTokens.removeFirst(), wantLogits = false, sampling = sampling)
+        }
+
+        val tokenToFeed = if (remainingPromptTokens.isEmpty()) tokenIds.last() else remainingPromptTokens.removeFirst()
+        val nextToken = feedToken(tokenToFeed, wantLogits = true, sampling = sampling)
+            ?: throw OnnxRuntimeError(kind = OnnxRuntimeErrorKind.INTERNAL_FAILURE, message = "model output malformed: missing '$LOGITS' output.")
+        tokenIds += nextToken
+        return nextToken
+    }
+
+    /**
+     * Feeds exactly one token (`input_ids`/`attention_mask` shape `[1, 1]`, matching this
+     * graph's fixed sequence-length-1 trace) and advances `pastKeyValues`/`fedCount`. Returns the
+     * sampled next token when `wantLogits` is set (the `logits` output is only requested then, to
+     * avoid computing/transferring it for the discarded prompt-replay steps), `null` otherwise.
+     */
+    private suspend fun feedToken(token: Long, wantLogits: Boolean, sampling: SamplingConfig): Long? {
+        val totalLength = fedCount + 1
+
+        return withContext(OnnxExecutionDispatcher.dispatcher) {
+            val inputIdsTensor = OnnxTensor.createTensor(loaded.environment, LongBuffer.wrap(longArrayOf(token)), longArrayOf(1, 1))
+            val attentionMaskTensor = OnnxTensor.createTensor(
+                loaded.environment,
+                LongBuffer.wrap(LongArray(totalLength) { 1L }),
+                longArrayOf(1, totalLength.toLong()),
+            )
+            val positionIdsTensor = if (layout.hasPositionIds) {
+                OnnxTensor.createTensor(loaded.environment, LongBuffer.wrap(longArrayOf(fedCount.toLong())), longArrayOf(1, 1))
+            } else {
+                null
+            }
+
+            try {
+                val inputs = mutableMapOf<String, OnnxTensorLike>(INPUT_IDS to inputIdsTensor, ATTENTION_MASK to attentionMaskTensor)
+                positionIdsTensor?.let { inputs[POSITION_IDS] = it }
+                inputs.putAll(pastKeyValues)
+
+                val outputNames = layout.presentOutputNames.toMutableSet()
+                if (wantLogits) outputNames += LOGITS
+
+                // The result's `present.*` outputs become the next step's `past_key_values.*`
+                // inputs -- not closed here, unlike the full-recompute path's result, since those
+                // tensors must outlive this call.
+                val result = runOnnxSession(loaded.session, inputs, outputNames)
+
+                val previousPastKeyValues = pastKeyValues
+                val nextPastKeyValues = mutableMapOf<String, OnnxTensor>()
+                for (layer in 0 until layout.numLayers) {
+                    for (part in listOf("key", "value")) {
+                        val presentName = "present.$layer.$part"
+                        val pastName = "$PAST_KEY_VALUES_PREFIX$layer.$part"
+                        nextPastKeyValues[pastName] = requireOutput(result, presentName)
+                    }
+                }
+                pastKeyValues = nextPastKeyValues
+                previousPastKeyValues.values.forEach { it.close() }
+                fedCount += 1
+
+                if (!wantLogits) return@withContext null
+                val logitsTensor = requireOutput(result, LOGITS)
+                selectNextToken(logitsTensor, sequenceLength = 1, sampling = sampling).also { logitsTensor.close() }
+            } finally {
+                inputIdsTensor.close()
+                attentionMaskTensor.close()
+                positionIdsTensor?.close()
+            }
+        }
+    }
+}
+
+private fun requireOutput(result: OrtSession.Result, name: String): OnnxTensor = result.get(name).orElseThrow {
+    OnnxRuntimeError(kind = OnnxRuntimeErrorKind.INTERNAL_FAILURE, message = "model output malformed: missing '$name' output.")
+} as OnnxTensor
+
+private fun directLongBuffer(capacity: Int): LongBuffer = ByteBuffer.allocateDirect(capacity * java.lang.Long.BYTES).order(ByteOrder.nativeOrder()).asLongBuffer()

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSampling.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSampling.kt
@@ -1,0 +1,126 @@
+package app.independo.inderun.providers.onnx
+
+import ai.onnxruntime.OnnxTensor
+import app.independo.inderun.contracts.Generation
+import kotlin.random.Random
+
+/**
+ * Reads the last-position logits row directly out of the tensor's backing [java.nio.FloatBuffer]
+ * rather than materializing the full `[sequenceLength x vocabSize]` tensor via [OnnxTensor.getValue]
+ * -- the decode loop only ever needs the last row -- then either argmaxes it (the default) or
+ * samples from it when [sampling] selects temperature/top-p sampling.
+ */
+internal fun selectNextToken(logits: OnnxTensor, sequenceLength: Int, sampling: SamplingConfig): Long {
+    val shape = logits.info.shape
+    if (shape.size != 3 || shape[0] != 1L || shape[1] != sequenceLength.toLong()) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.INTERNAL_FAILURE,
+            message = "model output malformed: unexpected logits shape ${shape.toList()}.",
+        )
+    }
+    val vocabSize = shape[2].toInt()
+
+    val buffer = logits.floatBuffer
+    val lastPositionOffset = (sequenceLength - 1) * vocabSize
+    if (buffer.limit() < lastPositionOffset + vocabSize) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.INTERNAL_FAILURE,
+            message = "model output malformed: logits buffer smaller than expected shape.",
+        )
+    }
+
+    val lastRow = FloatArray(vocabSize)
+    buffer.position(lastPositionOffset)
+    buffer.get(lastRow)
+
+    return sampling.selectToken(lastRow)
+}
+
+/**
+ * Generation controls this runtime honors as an alternative to argmax decoding.
+ *
+ * `temperature == null` (or `<= 0`) keeps the default, deterministic argmax behavior. Setting
+ * `temperature` switches to sampling: logits are scaled by `1 / temperature`, optionally narrowed
+ * to the smallest set of tokens whose cumulative probability reaches `topP` (nucleus sampling),
+ * then sampled. A `seed` makes sampling reproducible via [kotlin.random.Random], which is natively
+ * seedable -- unlike Apple's `SystemRandomNumberGenerator`, no custom seedable generator is needed.
+ */
+internal class SamplingConfig(generation: Generation?) {
+    private val temperature: Double? = generation?.temperature?.takeIf { it > 0 }
+    private val topP: Double? = generation?.topP
+    private val seed: Long? = generation?.seed
+    private val random: Random by lazy { seed?.let { Random(it) } ?: Random.Default }
+
+    fun selectToken(logits: FloatArray): Long {
+        val temperature = temperature ?: return argmax(logits).toLong()
+
+        val scaled = FloatArray(logits.size) { (logits[it] / temperature).toFloat() }
+        val probabilities = softmax(scaled)
+        val candidates = topPFiltered(probabilities, topP)
+        return sample(candidates).toLong()
+    }
+
+    private fun argmax(logits: FloatArray): Int {
+        var bestIndex = 0
+        var bestValue = Float.NEGATIVE_INFINITY
+        for (index in logits.indices) {
+            if (logits[index] > bestValue) {
+                bestValue = logits[index]
+                bestIndex = index
+            }
+        }
+        return bestIndex
+    }
+
+    private fun softmax(logits: FloatArray): FloatArray {
+        val maxValue = logits.maxOrNull() ?: 0f
+        val exponentiated = FloatArray(logits.size) { kotlin.math.exp((logits[it] - maxValue).toDouble()).toFloat() }
+        val sum = exponentiated.sum()
+        if (sum <= 0f) {
+            return FloatArray(logits.size) { 1f / logits.size }
+        }
+        return FloatArray(exponentiated.size) { exponentiated[it] / sum }
+    }
+
+    /**
+     * Narrows `probabilities` to the smallest prefix (sorted descending) whose cumulative mass
+     * reaches `topP`, renormalized so the remaining candidates sum to 1. Returns every index when
+     * `topP` is unset.
+     */
+    private fun topPFiltered(probabilities: FloatArray, topP: Double?): List<Pair<Int, Float>> {
+        val indexed = probabilities.mapIndexed { index, probability -> index to probability }
+        if (topP == null || topP <= 0 || topP >= 1) {
+            return indexed
+        }
+
+        val sorted = indexed.sortedByDescending { it.second }
+        var cumulative = 0f
+        var cutoff = sorted.size
+        for ((position, entry) in sorted.withIndex()) {
+            cumulative += entry.second
+            if (cumulative >= topP.toFloat()) {
+                cutoff = position + 1
+                break
+            }
+        }
+        val selected = sorted.take(cutoff)
+        val total = selected.sumOf { it.second.toDouble() }.toFloat()
+        if (total <= 0f) {
+            return indexed
+        }
+        return selected.map { (index, probability) -> index to probability / total }
+    }
+
+    private fun sample(candidates: List<Pair<Int, Float>>): Int {
+        if (candidates.isEmpty()) return 0
+        val target = random.nextFloat()
+        var cumulative = 0f
+        for ((index, probability) in candidates) {
+            cumulative += probability
+            if (target < cumulative) {
+                return index
+            }
+        }
+        return candidates.last().first
+    }
+}

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoading.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoading.kt
@@ -1,0 +1,400 @@
+package app.independo.inderun.providers.onnx
+
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtException
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import app.independo.inderun.contracts.Format
+import app.independo.inderun.contracts.ModelPackage
+import app.independo.inderun.contracts.SourceType
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * A tokenizer + ORT session resolved and loaded for a specific model package, plus the decode
+ * strategy auto-detected from the graph's declared input names at load time.
+ */
+internal data class LoadedSession(
+    val cacheKey: String,
+    val environment: OrtEnvironment,
+    val session: OrtSession,
+    val tokenizer: HuggingFaceTokenizer,
+    val eosTokenId: Long?,
+    val decodeStrategy: DecodeStrategy,
+) {
+    fun close() {
+        session.close()
+        tokenizer.close()
+    }
+}
+
+/**
+ * Lazily resolves and caches the loaded session for the most recently requested model package, so
+ * repeated `prepare`/`generate` calls do not reload the model and tokenizer every time. A changed
+ * `version`/`ref`/checksum evicts the stale session rather than silently reusing it.
+ */
+internal class LoadedSessionBox(private val context: Context) {
+    private val mutex = Mutex()
+    private var cached: LoadedSession? = null
+
+    suspend fun loaded(modelPackage: ModelPackage): LoadedSession = mutex.withLock {
+        val cacheKey = sessionCacheKey(modelPackage)
+        cached?.takeIf { it.cacheKey == cacheKey }?.let { return it }
+
+        cached?.close()
+        cached = null
+
+        val loaded = withContext(OnnxExecutionDispatcher.dispatcher) { load(modelPackage, cacheKey) }
+        cached = loaded
+        loaded
+    }
+
+    private fun load(modelPackage: ModelPackage, cacheKey: String): LoadedSession {
+        if (modelPackage.format != Format.Onnx && modelPackage.format != Format.Ort) {
+            throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "unsupported model format: '${modelPackage.format}' is not supported by the " +
+                    "Android ONNX Runtime member (expected 'onnx' or 'ort').",
+            )
+        }
+
+        val sourceType = modelPackage.source?.sourceType
+            ?: throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "model source unavailable: no model source was configured.",
+            )
+
+        val directory = resolveDirectory(modelPackage, sourceType, cacheKey)
+        val requiredFiles = modelPackage.files?.required.orEmpty()
+        if (requiredFiles.isEmpty()) {
+            throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "model files missing: model package '${modelPackage.id}' declares no required files.",
+            )
+        }
+
+        val graphFile = File(directory, requiredFiles.first())
+        requiredFiles.forEach { relativePath ->
+            val file = File(directory, relativePath)
+            if (!file.exists()) {
+                throw OnnxRuntimeError(
+                    kind = OnnxRuntimeErrorKind.CAPABILITY,
+                    message = "model files missing: '$relativePath' not found at ${file.absolutePath}.",
+                )
+            }
+        }
+        verifyChecksums(directory, modelPackage)
+
+        val tokenizerFile = modelPackage.files?.tokenizer?.let { File(directory, it) }
+
+        val environment = OrtEnvironment.getEnvironment()
+        var session = makeSession(environment, graphFile, useNnapi = true)
+        val decodeStrategy = detectDecodeStrategy(session, directory)
+
+        // NNAPI's behavior on the KV-cache path's genuinely zero-length initial `past_key_values`
+        // tensor is unverified on-device (see #88); the Apple member's CoreML EP rejects an
+        // analogous zero-length dynamic-shaped input at run time, so the KV-cache path
+        // conservatively never uses NNAPI here either, on the same reasoning, not a confirmed
+        // Android-device finding. Re-creating the session is the only option: the execution
+        // provider list is fixed at session-creation time.
+        if (decodeStrategy is DecodeStrategy.KvCache) {
+            session.close()
+            session = makeSession(environment, graphFile, useNnapi = false)
+        }
+
+        val tokenizer = try {
+            if (tokenizerFile != null && tokenizerFile.exists()) {
+                HuggingFaceTokenizer.newInstance(tokenizerFile.toPath())
+            } else {
+                HuggingFaceTokenizer.newInstance(directory.toPath())
+            }
+        } catch (error: Throwable) {
+            session.close()
+            throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "tokenizer/config missing: unable to load a tokenizer for '${modelPackage.id}'.",
+                originalError = error,
+            )
+        }
+
+        val eosTokenId = resolveEosTokenId(directory, modelPackage)
+
+        return LoadedSession(
+            cacheKey = cacheKey,
+            environment = environment,
+            session = session,
+            tokenizer = tokenizer,
+            eosTokenId = eosTokenId,
+            decodeStrategy = decodeStrategy,
+        )
+    }
+
+    private fun makeSession(environment: OrtEnvironment, graphFile: File, useNnapi: Boolean): OrtSession = try {
+        environment.createSession(graphFile.absolutePath, makeSessionOptions(useNnapi))
+    } catch (error: Throwable) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.UNAVAILABLE,
+            message = "runtime initialization failed: unable to create an ONNX Runtime session for " +
+                "'${graphFile.name}'.",
+            originalError = error,
+        )
+    }
+
+    /**
+     * Configures the NNAPI execution provider by default (when [useNnapi]), falling back to
+     * XNNPACK and then ORT's default CPU EP if NNAPI configuration fails on this device/OS --
+     * NNAPI's availability varies across hardware and Android versions, so this must degrade
+     * rather than fail session creation. `useNnapi: false` skips straight to XNNPACK/CPU, for
+     * graphs NNAPI cannot run at all (see the KV-cache zero-length-tensor note at this method's
+     * call site). `intraOpNumThreads` is set explicitly (bounded by the device's available
+     * processor count) rather than left at ORT's implicit default.
+     */
+    private fun makeSessionOptions(useNnapi: Boolean): OrtSession.SessionOptions {
+        val options = OrtSession.SessionOptions()
+        val threadCount = minOf(4, maxOf(1, Runtime.getRuntime().availableProcessors()))
+        try {
+            options.setIntraOpNumThreads(threadCount)
+        } catch (error: OrtException) {
+            // Falls back to ORT's implicit default thread count.
+        }
+
+        val nnapiEnabled = useNnapi && try {
+            options.addNnapi()
+            true
+        } catch (error: OrtException) {
+            false
+        }
+        if (!nnapiEnabled) {
+            try {
+                options.addXnnpack(mapOf("intra_op_num_threads" to threadCount.toString()))
+            } catch (error: OrtException) {
+                // Falls back to ORT's default CPU execution provider.
+            }
+        }
+        return options
+    }
+
+    private fun resolveDirectory(modelPackage: ModelPackage, sourceType: SourceType, cacheKey: String): File {
+        val ref = modelPackage.source?.ref
+        return when (sourceType) {
+            SourceType.Bundled -> {
+                val relative = ref.orEmpty()
+                val assetDir = File(
+                    context.filesDir,
+                    "inderun-onnx-assets/${modelPackage.id}/${cacheKeyDigest(cacheKey)}",
+                )
+                extractAssetDirectory(relative, assetDir)
+                assetDir
+            }
+            SourceType.Filesystem -> {
+                if (ref.isNullOrEmpty()) {
+                    throw OnnxRuntimeError(
+                        kind = OnnxRuntimeErrorKind.CAPABILITY,
+                        message = "model source unavailable: a 'filesystem' model source requires 'source.ref'.",
+                    )
+                }
+                File(ref)
+            }
+            SourceType.AppManaged -> {
+                val base = context.filesDir
+                if (ref.isNullOrEmpty()) base else File(base, ref)
+            }
+            SourceType.Programmatic -> throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "runtime package unavailable: 'programmatic' model sources have no files to " +
+                    "resolve; supply a custom AndroidOnnxGenAiRuntime instead.",
+            )
+            SourceType.Registry, SourceType.Remote -> throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "model source unavailable: '${sourceType.name.lowercase()}' model sources are " +
+                    "deferred on Android.",
+            )
+        }
+    }
+
+    /**
+     * Extracts a bundled asset directory into app-private storage exactly once per
+     * [cacheKeyDigest], atomically: the copy lands in a sibling temp directory, a completion
+     * marker is written last, and only then is the temp directory moved into place. A directory
+     * missing the marker (never completed, or a previous run crashed mid-copy) is re-extracted
+     * rather than trusted.
+     */
+    private fun extractAssetDirectory(assetPath: String, targetDir: File) {
+        if (File(targetDir, EXTRACTION_COMPLETE_MARKER).exists()) return
+
+        val tempDir = File(targetDir.parentFile, "${targetDir.name}.tmp-${System.nanoTime()}")
+        tempDir.deleteRecursively()
+        tempDir.mkdirs()
+        try {
+            copyAssetTree(assetPath, tempDir)
+            val completionMarker = File(tempDir, EXTRACTION_COMPLETE_MARKER)
+            if (!completionMarker.createNewFile()) {
+                throw IllegalStateException(
+                    "failed to create extraction completion marker '$EXTRACTION_COMPLETE_MARKER'.",
+                )
+            }
+        } catch (error: Throwable) {
+            tempDir.deleteRecursively()
+            throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "model source unavailable: failed to extract bundled model assets for '$assetPath'.",
+                originalError = error,
+            )
+        }
+
+        targetDir.deleteRecursively()
+        if (!tempDir.renameTo(targetDir)) {
+            tempDir.deleteRecursively()
+            throw OnnxRuntimeError(
+                kind = OnnxRuntimeErrorKind.CAPABILITY,
+                message = "model source unavailable: failed to install extracted model assets for '$assetPath'.",
+            )
+        }
+    }
+
+    private fun copyAssetTree(assetPath: String, targetDir: File) {
+        val assetManager = context.assets
+        val entries = assetManager.list(assetPath).orEmpty()
+        entries.forEach { entry ->
+            val childAssetPath = if (assetPath.isEmpty()) entry else "$assetPath/$entry"
+            val childEntries = assetManager.list(childAssetPath)
+            if (childEntries.isNullOrEmpty()) {
+                assetManager.open(childAssetPath).use { input ->
+                    File(targetDir, entry).outputStream().use { output -> input.copyTo(output) }
+                }
+            } else {
+                val childDir = File(targetDir, entry)
+                childDir.mkdirs()
+                copyAssetTree(childAssetPath, childDir)
+            }
+        }
+    }
+
+    /**
+     * Verifies every file named in `integrity.checksums`, not only the required-file list, so a
+     * checksum declared for the tokenizer or config file is enforced too. Files the map names but
+     * that this runtime did not resolve a path for are skipped; an unsupported checksum algorithm
+     * is a capability failure rather than a silently skipped check.
+     */
+    private fun verifyChecksums(directory: File, modelPackage: ModelPackage) {
+        val checksums = modelPackage.integrity?.checksums ?: return
+        for ((relativePath, expected) in checksums) {
+            val file = File(directory, relativePath)
+            if (!file.exists()) continue
+            verifyChecksum(file, relativePath, expected)
+        }
+    }
+
+    /**
+     * Resolves the tokenizer's end-of-sequence token id from the model config JSON's
+     * `eos_token_id` field. The DJL tokenizer binding does not expose special token ids directly,
+     * unlike `swift-transformers` on Apple, so this runtime reads the config file itself. Absence
+     * of a resolvable config or field means generation relies solely on
+     * `generation.stop`/`maxOutputTokens`, not on EOS detection.
+     */
+    private fun resolveEosTokenId(directory: File, modelPackage: ModelPackage): Long? {
+        val configFile = modelPackage.files?.config?.let { File(directory, it) }
+            ?: File(directory, "config.json").takeIf { it.exists() }
+            ?: return null
+        if (!configFile.exists()) return null
+
+        return try {
+            parseEosTokenId(configFile.readText())
+        } catch (error: Throwable) {
+            null
+        }
+    }
+
+    private companion object {
+        const val EXTRACTION_COMPLETE_MARKER = ".inderun-onnx-extraction-complete"
+    }
+}
+
+/**
+ * Cache key covering everything that identifies *which bytes* this session was built from -- `id`
+ * alone does not: an app can swap a bundled model file, change `source.ref`, or bump `version`
+ * while keeping the same `id`, and a stale cached session would silently keep serving the old
+ * model.
+ */
+internal fun sessionCacheKey(modelPackage: ModelPackage): String {
+    val checksums = modelPackage.integrity?.checksums?.entries
+        ?.sortedBy { it.key }
+        ?.joinToString(separator = ",") { "${it.key}=${it.value}" }
+        .orEmpty()
+    return listOf(
+        modelPackage.id,
+        modelPackage.format.name,
+        modelPackage.version.orEmpty(),
+        modelPackage.source?.sourceType?.name.orEmpty(),
+        modelPackage.source?.ref.orEmpty(),
+        checksums,
+    ).joinToString(separator = "|")
+}
+
+/**
+ * Verifies a single resolved file against a `algorithm:hex` checksum string. Only `sha256` is
+ * supported; any other algorithm prefix is a capability failure rather than a silently skipped
+ * check, since the schema permits arbitrary non-empty checksum strings and a configured-but-unknown
+ * algorithm must not be mistaken for "no integrity check requested".
+ */
+internal fun verifyChecksum(file: File, relativePath: String, expected: String) {
+    val prefix = "sha256:"
+    if (!expected.startsWith(prefix, ignoreCase = true)) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.CAPABILITY,
+            message = "checksum/integrity mismatch: unsupported checksum algorithm for '$relativePath' " +
+                "(only 'sha256:<hex>' is supported).",
+        )
+    }
+
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var read = input.read(buffer)
+        while (read >= 0) {
+            digest.update(buffer, 0, read)
+            read = input.read(buffer)
+        }
+    }
+    val actual = digest.digest().joinToString(separator = "") { "%02x".format(it) }
+    val expectedHex = expected.substring(prefix.length)
+    if (!actual.equals(expectedHex, ignoreCase = true)) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.CAPABILITY,
+            message = "checksum/integrity mismatch: '$relativePath' does not match the expected checksum.",
+        )
+    }
+}
+
+/**
+ * Extracts `eos_token_id` from a Hugging Face-style `config.json` payload. The field is either a
+ * plain integer or a list of integers (some model configs declare multiple eos candidates); the
+ * first value is used either way. Returns `null` when the field is absent or malformed.
+ */
+internal fun parseEosTokenId(configJson: String): Long? {
+    val json = JSONObject(configJson)
+    if (!json.has("eos_token_id")) return null
+
+    val value = json.get("eos_token_id")
+    return when (value) {
+        is Int -> value.toLong()
+        is Long -> value
+        is org.json.JSONArray -> if (value.length() > 0) value.getLong(0) else null
+        else -> null
+    }
+}
+
+/**
+ * Short, filesystem-safe digest of a session cache key, used to key extracted-asset directories so
+ * a changed model identity (version/source/checksums) extracts into a fresh directory instead of
+ * reusing stale bytes copied under an older identity.
+ */
+internal fun cacheKeyDigest(cacheKey: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray(Charsets.UTF_8))
+    return digest.joinToString(separator = "") { "%02x".format(it) }.take(16)
+}

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoading.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoading.kt
@@ -163,11 +163,15 @@ internal class LoadedSessionBox(private val context: Context) {
             // Falls back to ORT's implicit default thread count.
         }
 
-        val nnapiEnabled = useNnapi && try {
-            options.addNnapi()
-            true
-        } catch (error: OrtException) {
+        val nnapiEnabled = if (!useNnapi) {
             false
+        } else {
+            try {
+                options.addNnapi()
+                true
+            } catch (error: OrtException) {
+                false
+            }
         }
         if (!nnapiEnabled) {
             try {

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoadingKvCacheDetection.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoadingKvCacheDetection.kt
@@ -1,0 +1,163 @@
+package app.independo.inderun.providers.onnx
+
+import ai.onnxruntime.OnnxTensor
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import org.json.JSONObject
+import java.io.File
+import java.nio.FloatBuffer
+
+/**
+ * The decode contract this runtime detected for a loaded graph. [KvCache] is chosen only when
+ * every assumption the KV-cache decode path depends on (layer count, head count, head dimension,
+ * per-layer `past_key_values`/`present` naming) is resolvable from the graph's declared input
+ * names and the model directory's `config.json`; anything unresolvable conservatively falls back
+ * to [FullRecompute] rather than guessing.
+ */
+internal sealed class DecodeStrategy {
+    data object FullRecompute : DecodeStrategy()
+    data class KvCache(val layout: KvCacheLayout) : DecodeStrategy()
+}
+
+/**
+ * Static geometry the KV-cache decode path needs to build empty initial `past_key_values` tensors
+ * and locate this graph's `present.*` outputs, resolved once at load time.
+ */
+internal data class KvCacheLayout(
+    val numLayers: Int,
+    val numKeyValueHeads: Int,
+    val headDim: Int,
+    val hasPositionIds: Boolean,
+) {
+    val presentOutputNames: List<String>
+        get() = (0 until numLayers).flatMap { layer -> listOf("present.$layer.key", "present.$layer.value") }
+
+    /**
+     * Zero-length `past_key_values.*` tensors for the first decode step: shape
+     * `[1, numKeyValueHeads, 0, headDim]` -- the sequence-length axis starts empty and grows as
+     * `present.*` outputs replace these tensors after each step.
+     */
+    fun emptyPastKeyValues(environment: OrtEnvironment): Map<String, OnnxTensor> {
+        val shape = longArrayOf(1, numKeyValueHeads.toLong(), 0, headDim.toLong())
+        val result = mutableMapOf<String, OnnxTensor>()
+        for (layer in 0 until numLayers) {
+            for (part in listOf("key", "value")) {
+                result["past_key_values.$layer.$part"] = OnnxTensor.createTensor(environment, FloatBuffer.allocate(0), shape)
+            }
+        }
+        return result
+    }
+}
+
+/**
+ * Auto-detects the decode strategy from the graph's declared input names, so no [app.independo
+ * .inderun.contracts.ModelPackage] field or app-facing configuration is needed to pick between the
+ * plain and KV-cache IO contracts. Falls back to [DecodeStrategy.FullRecompute] -- always
+ * supported -- whenever any KV-cache assumption (naming convention, resolvable `config.json`
+ * architecture fields) doesn't hold, rather than guessing.
+ */
+internal fun detectDecodeStrategy(session: OrtSession, directory: File): DecodeStrategy = detectDecodeStrategy(session.inputNames, session.outputNames, directory)
+
+/**
+ * Pure variant of [detectDecodeStrategy] taking the graph's declared input/output names directly,
+ * independent of [OrtSession] -- lets KV-cache detection be exercised in unit tests against
+ * synthetic name sets without a real ONNX Runtime native session (unavailable in this module's
+ * unit test environment).
+ */
+internal fun detectDecodeStrategy(inputNames: Set<String>, outputNames: Set<String>, directory: File): DecodeStrategy {
+    val hasPastKeyValues = inputNames.any { it.startsWith("past_key_values.") }
+    if (!hasPastKeyValues) {
+        return DecodeStrategy.FullRecompute
+    }
+
+    val layout = try {
+        kvCacheLayout(inputNames, outputNames, directory)
+    } catch (error: Throwable) {
+        null
+    }
+    return layout?.let { DecodeStrategy.KvCache(it) } ?: DecodeStrategy.FullRecompute
+}
+
+private fun kvCacheLayout(inputNames: Set<String>, outputNames: Set<String>, directory: File): KvCacheLayout {
+    val configFile = File(directory, "config.json")
+    if (!configFile.exists()) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.CAPABILITY,
+            message = "model files missing: 'config.json' not found for KV-cache detection.",
+        )
+    }
+    val config = JSONObject(configFile.readText())
+
+    // Field names vary by architecture family: Llama-style configs use
+    // `num_hidden_layers`/`num_attention_heads`/`hidden_size`; GPT-2-style configs (still common
+    // among small quantized decoder-with-past exports) use `n_layer`/`n_head`/`n_embd` instead.
+    // Both are read so KV-cache detection isn't silently GPT-2-blind.
+    val numLayers = intField(config, "num_hidden_layers", "n_layer")
+        ?: throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.CAPABILITY,
+            message = "model package malformed: 'config.json' missing 'num_hidden_layers'/'n_layer'.",
+        )
+
+    val numAttentionHeads = intField(config, "num_attention_heads", "n_head")
+    val numKeyValueHeads = intField(config, "num_key_value_heads") ?: numAttentionHeads
+        ?: throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.CAPABILITY,
+            message = "model package malformed: 'config.json' missing attention head count.",
+        )
+
+    val headDim = intField(config, "head_dim")
+        ?: run {
+            val hiddenSize = intField(config, "hidden_size", "n_embd")
+            if (hiddenSize != null && numAttentionHeads != null && numAttentionHeads > 0) {
+                hiddenSize / numAttentionHeads
+            } else {
+                throw OnnxRuntimeError(
+                    kind = OnnxRuntimeErrorKind.CAPABILITY,
+                    message = "model package malformed: 'config.json' missing 'hidden_size'/'n_embd'/'head_dim'.",
+                )
+            }
+        }
+
+    // `use_cache_branch` (some merged Optimum exports' boolean cache-branch selector) needs a
+    // dedicated calling convention this runtime does not implement -- conservatively fall back to
+    // full recompute for such graphs rather than feeding a mismatched call.
+    if (inputNames.contains("use_cache_branch")) {
+        throw OnnxRuntimeError(
+            kind = OnnxRuntimeErrorKind.CAPABILITY,
+            message = "unsupported model format: 'use_cache_branch' input is not supported by this runtime's KV-cache path.",
+        )
+    }
+
+    for (layer in 0 until numLayers) {
+        for (part in listOf("key", "value")) {
+            if (!inputNames.contains("past_key_values.$layer.$part")) {
+                throw OnnxRuntimeError(
+                    kind = OnnxRuntimeErrorKind.CAPABILITY,
+                    message = "model package malformed: missing 'past_key_values.$layer.$part' input.",
+                )
+            }
+            if (!outputNames.contains("present.$layer.$part")) {
+                throw OnnxRuntimeError(
+                    kind = OnnxRuntimeErrorKind.CAPABILITY,
+                    message = "model package malformed: missing 'present.$layer.$part' output.",
+                )
+            }
+        }
+    }
+
+    return KvCacheLayout(
+        numLayers = numLayers,
+        numKeyValueHeads = numKeyValueHeads,
+        headDim = headDim,
+        hasPositionIds = inputNames.contains("position_ids"),
+    )
+}
+
+private fun intField(config: JSONObject, vararg keys: String): Int? {
+    for (key in keys) {
+        if (config.has(key)) {
+            return config.optInt(key)
+        }
+    }
+    return null
+}

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxTensorExecution.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/OnnxTensorExecution.kt
@@ -1,0 +1,42 @@
+package app.independo.inderun.providers.onnx
+
+import ai.onnxruntime.OnnxTensorLike
+import ai.onnxruntime.OrtException
+import ai.onnxruntime.OrtSession
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+
+/**
+ * Runs ONNX Runtime session creation and `run()` calls on a dedicated single-thread dispatcher
+ * rather than [kotlinx.coroutines.Dispatchers.IO]/[kotlinx.coroutines.Dispatchers.Default]:
+ * `OrtSession.run()` and session construction are blocking synchronous calls, and sharing them
+ * with the general-purpose coroutine pools has no dedicated thread-policy story. A single thread
+ * is sufficient -- a single generation is inherently sequential token-by-token -- and gives
+ * cancellation-adjacent work one well-defined place to execute, mirroring the Apple member's
+ * `OnnxExecutionQueue`.
+ */
+internal object OnnxExecutionDispatcher {
+    val dispatcher = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "inderun-onnx-execution")
+    }.asCoroutineDispatcher()
+}
+
+/**
+ * Runs `session.run(inputs, outputNames)` and wraps any raw [OrtException] (missing/mistyped
+ * input, shape mismatch, and similar) into an [OnnxRuntimeError] carrying the original error as
+ * detail, rather than letting an opaque native error propagate uncaught up to the provider's
+ * generic "execution failed" fallback.
+ */
+internal fun runOnnxSession(
+    session: OrtSession,
+    inputs: Map<String, OnnxTensorLike>,
+    outputNames: Set<String>,
+): OrtSession.Result = try {
+    session.run(inputs, outputNames)
+} catch (error: OrtException) {
+    throw OnnxRuntimeError(
+        kind = OnnxRuntimeErrorKind.UNAVAILABLE,
+        message = "ONNX Runtime session execution failed.",
+        originalError = error,
+    )
+}

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/SystemAndroidOnnxGenAiRuntime.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/SystemAndroidOnnxGenAiRuntime.kt
@@ -1,24 +1,10 @@
 package app.independo.inderun.providers.onnx
 
-import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer
-import ai.onnxruntime.OnnxTensor
-import ai.onnxruntime.OrtEnvironment
-import ai.onnxruntime.OrtSession
 import android.content.Context
 import app.independo.inderun.contracts.FinishReason
-import app.independo.inderun.contracts.Format
 import app.independo.inderun.contracts.ModelPackage
-import app.independo.inderun.contracts.SourceType
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import org.json.JSONObject
-import java.io.File
-import java.nio.LongBuffer
-import java.security.MessageDigest
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -26,30 +12,39 @@ import kotlin.coroutines.coroutineContext
  * (`com.microsoft.onnxruntime:onnxruntime-android`) and a Hugging Face tokenizer
  * (`ai.djl.huggingface:tokenizers`).
  *
- * **IO contract**: the model graph must expose exactly `input_ids` and `attention_mask` inputs
- * (`int64`, `[1, sequenceLength]`) and a `logits` output (`float32`, `[1, sequenceLength,
- * vocabSize]`) -- the plain decoder-only export shape, without `past_key_values`. This mirrors the
- * Apple member's `SystemOnnxGenAiRuntime`.
+ * **IO contract**: this runtime auto-detects, from the loaded graph's declared input names, which
+ * of two decoder-only export shapes a model uses -- no [ModelPackage] field or app-facing
+ * configuration selects it (see [detectDecodeStrategy] in `OnnxSessionLoadingKvCacheDetection.kt`).
+ * Both require `input_ids`/`attention_mask` (`int64`) and a `logits` output (`float32`, `[1,
+ * sequenceLength, vocabSize]`):
  *
- * **Graph file convention**: [ModelPackage.files]'s `required` list has no positional semantics of
- * its own in the schema, so this runtime defines one -- the *first* entry is the ONNX graph file;
- * any remaining entries (for example external weight shards) must be present alongside it but are
- * not referenced directly. Every file named in [ModelPackage.integrity]'s checksum map is verified
- * (`sha256:<hex>` only; any other algorithm prefix is a capability failure, not a silently skipped
- * check), before load.
+ * - **Plain** (no `past_key_values.*` inputs, [DecodeStrategy.FullRecompute]): the full sequence
+ *   is recomputed on every decode step. Always supported; the fallback when KV-cache detection
+ *   can't establish every assumption below.
+ * - **KV-cache** ([DecodeStrategy.KvCache], matching the legacy (non-merged) Hugging Face Optimum
+ *   `decoder_with_past_model` export convention): exactly one token is fed as `input_ids` per
+ *   model call, the prompt replayed one token at a time first. Requires `num_hidden_layers` (or
+ *   GPT-2-style `n_layer`), `num_attention_heads`/`n_head` (or `num_key_value_heads`), and
+ *   `hidden_size`/`n_embd` (or `head_dim`) to be readable from `config.json`. Mirrors the Apple
+ *   member's `KvCacheDecoder`; see `OnnxDecoders.kt`.
  *
- * **Stop conditions.** Generation stops on the tokenizer's end-of-sequence token (resolved from the
- * model config JSON's `eos_token_id`, since the DJL tokenizer binding does not expose it directly),
- * on a `generation.stop` suffix match, or once `generation.maxOutputTokens` tokens have been
- * produced -- whichever comes first. Coroutine cancellation is checked before every decode step
- * (`cancel: soft`: `OrtSession.run()` itself cannot be interrupted mid-call).
+ * **Decode loop.** Generation defaults to greedy (argmax); `generation.temperature`/`topP`/`seed`
+ * select sampling instead (see `OnnxSampling.kt`). `generation.stop` sequences are honored. Session
+ * creation and every `run()` call execute on a dedicated single-thread dispatcher rather than
+ * [kotlinx.coroutines.Dispatchers.IO]/[kotlinx.coroutines.Dispatchers.Default], since
+ * `OrtSession.run()` is a blocking synchronous call (`OnnxTensorExecution.kt`). `OrtEnvironment` is
+ * already a process-wide singleton per its own Java API contract (`OrtEnvironment.getEnvironment()`),
+ * so no separate shared-instance wrapper is needed, unlike the Apple member's `ORTEnv`. The NNAPI
+ * execution provider is configured by default on the plain decode path, falling back to XNNPACK
+ * and then ORT's default CPU EP if NNAPI is unavailable on the host; the KV-cache path never uses
+ * NNAPI (see `OnnxSessionLoading.kt`). See
+ * `docs/architecture/onnx-runtime-provider-family.md` for the full specification and residual
+ * risks -- none of the above has been exercised on a real device or model; that remains #88.
  *
- * Decoding is **greedy (argmax) with no KV-cache reuse**: the full sequence is recomputed on every
- * generated token, CPU execution provider only. `temperature`/`topP`/`seed` are not honored (no
- * sampling, argmax only). This is a real, documented performance limitation, not a hidden one. Chat
- * formatting falls back to a plain `"role: content"` join -- unlike the Apple/Web members, no
- * chat-template application is attempted, since Hugging Face chat-template support in the Android
- * tokenizer binding is not guaranteed across models.
+ * **Chat formatting.** Chat-template application is not attempted: `ai.djl.huggingface:tokenizers`
+ * exposes no `applyChatTemplate`-equivalent API (verified against its `0.33.0` public surface), so
+ * this is a permanent gap for this runtime, not an oversight pending evaluation -- unlike the
+ * Apple/Web members. Input always falls back to a plain `"role: content"` join.
  *
  * **Bundled asset extraction.** `bundled` sources are copied from Android assets into app-private
  * storage under a directory keyed by the session cache key (id/format/version/source/checksums), so
@@ -60,15 +55,14 @@ import kotlin.coroutines.coroutineContext
  * `programmatic` model sources are out of scope for this default runtime (no files to resolve,
  * matching the Web/Apple members' own `programmatic` carve-out); it reports *runtime package
  * unavailable* rather than throwing. This default runtime has not been run against a real model
- * on-device -- real-device verification is tracked alongside the Apple member's own follow-up.
+ * on-device -- real-device verification is tracked alongside the Apple member's own follow-up (#88).
  */
-class SystemAndroidOnnxGenAiRuntime(private val context: Context) : AndroidOnnxGenAiRuntime {
+class SystemAndroidOnnxGenAiRuntime(context: Context) : AndroidOnnxGenAiRuntime {
 
-    private val sessionMutex = Mutex()
-    private var cachedSession: LoadedSession? = null
+    private val session = LoadedSessionBox(context)
 
     override suspend fun prepare(modelPackage: ModelPackage): AndroidOnnxRuntimeAvailability = try {
-        withContext(Dispatchers.IO) { loadSession(modelPackage) }
+        session.loaded(modelPackage)
         AndroidOnnxRuntimeAvailability(available = true)
     } catch (error: CancellationException) {
         throw error
@@ -81,337 +75,59 @@ class SystemAndroidOnnxGenAiRuntime(private val context: Context) : AndroidOnnxG
         )
     }
 
-    override suspend fun generate(input: AndroidOnnxGenerationInput): AndroidOnnxGenerationOutput = withContext(Dispatchers.Default) {
-        val session = withContext(Dispatchers.IO) { loadSession(input.modelPackage) }
+    override suspend fun generate(input: AndroidOnnxGenerationInput): AndroidOnnxGenerationOutput {
+        val loaded = session.loaded(input.modelPackage)
         val prompt = formatMessages(input.messages)
-        val text = decode(session, prompt, input)
-        AndroidOnnxGenerationOutput(text = text, finishReason = FinishReason.STOP)
-    }
-
-    private suspend fun loadSession(modelPackage: ModelPackage): LoadedSession = sessionMutex.withLock {
-        val cacheKey = sessionCacheKey(modelPackage)
-        cachedSession?.takeIf { it.cacheKey == cacheKey }?.let { return it }
-
-        cachedSession?.close()
-        cachedSession = null
-
-        val loaded = openSession(modelPackage, cacheKey)
-        cachedSession = loaded
-        loaded
-    }
-
-    private fun openSession(modelPackage: ModelPackage, cacheKey: String): LoadedSession {
-        if (modelPackage.format != Format.Onnx && modelPackage.format != Format.Ort) {
-            throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "unsupported model format: '${modelPackage.format}' is not supported by the " +
-                    "Android ONNX Runtime member (expected 'onnx' or 'ort').",
-            )
-        }
-
-        val sourceType = modelPackage.source?.sourceType
-            ?: throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "model source unavailable: no model source was configured.",
-            )
-
-        val directory = resolveDirectory(modelPackage, sourceType, cacheKey)
-        val requiredFiles = modelPackage.files?.required.orEmpty()
-        if (requiredFiles.isEmpty()) {
-            throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "model files missing: model package '${modelPackage.id}' declares no required files.",
-            )
-        }
-
-        val graphFile = File(directory, requiredFiles.first())
-        requiredFiles.forEach { relativePath ->
-            val file = File(directory, relativePath)
-            if (!file.exists()) {
-                throw OnnxRuntimeError(
-                    kind = OnnxRuntimeErrorKind.CAPABILITY,
-                    message = "model files missing: '$relativePath' not found at ${file.absolutePath}.",
-                )
-            }
-        }
-        verifyChecksums(directory, modelPackage)
-
-        val tokenizerFile = modelPackage.files?.tokenizer?.let { File(directory, it) }
-
-        val ortEnvironment = OrtEnvironment.getEnvironment()
-        val session = try {
-            ortEnvironment.createSession(graphFile.absolutePath, OrtSession.SessionOptions())
-        } catch (error: Throwable) {
-            throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.UNAVAILABLE,
-                message = "runtime initialization failed: unable to create an ONNX Runtime session for " +
-                    "'${modelPackage.id}'.",
-                originalError = error,
-            )
-        }
-
-        val tokenizer = try {
-            if (tokenizerFile != null && tokenizerFile.exists()) {
-                HuggingFaceTokenizer.newInstance(tokenizerFile.toPath())
-            } else {
-                HuggingFaceTokenizer.newInstance(directory.toPath())
-            }
-        } catch (error: Throwable) {
-            session.close()
-            throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "tokenizer/config missing: unable to load a tokenizer for '${modelPackage.id}'.",
-                originalError = error,
-            )
-        }
-
-        val eosTokenId = resolveEosTokenId(directory, modelPackage)
-
-        return LoadedSession(
-            cacheKey = cacheKey,
-            environment = ortEnvironment,
-            session = session,
-            tokenizer = tokenizer,
-            eosTokenId = eosTokenId,
-        )
-    }
-
-    private fun resolveDirectory(modelPackage: ModelPackage, sourceType: SourceType, cacheKey: String): File {
-        val ref = modelPackage.source?.ref
-        return when (sourceType) {
-            SourceType.Bundled -> {
-                val relative = ref.orEmpty()
-                val assetDir = File(
-                    context.filesDir,
-                    "inderun-onnx-assets/${modelPackage.id}/${cacheKeyDigest(cacheKey)}",
-                )
-                extractAssetDirectory(relative, assetDir)
-                assetDir
-            }
-            SourceType.Filesystem -> {
-                if (ref.isNullOrEmpty()) {
-                    throw OnnxRuntimeError(
-                        kind = OnnxRuntimeErrorKind.CAPABILITY,
-                        message = "model source unavailable: a 'filesystem' model source requires 'source.ref'.",
-                    )
-                }
-                File(ref)
-            }
-            SourceType.AppManaged -> {
-                val base = context.filesDir
-                if (ref.isNullOrEmpty()) base else File(base, ref)
-            }
-            SourceType.Programmatic -> throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "runtime package unavailable: 'programmatic' model sources have no files to " +
-                    "resolve; supply a custom AndroidOnnxGenAiRuntime instead.",
-            )
-            SourceType.Registry, SourceType.Remote -> throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "model source unavailable: '${sourceType.name.lowercase()}' model sources are " +
-                    "deferred on Android.",
-            )
-        }
-    }
-
-    /**
-     * Extracts a bundled asset directory into app-private storage exactly once per
-     * [cacheKeyDigest], atomically: the copy lands in a sibling temp directory, a completion
-     * marker is written last, and only then is the temp directory moved into place. A directory
-     * missing the marker (never completed, or a previous run crashed mid-copy) is re-extracted
-     * rather than trusted.
-     */
-    private fun extractAssetDirectory(assetPath: String, targetDir: File) {
-        if (File(targetDir, EXTRACTION_COMPLETE_MARKER).exists()) return
-
-        val tempDir = File(targetDir.parentFile, "${targetDir.name}.tmp-${System.nanoTime()}")
-        tempDir.deleteRecursively()
-        tempDir.mkdirs()
-        try {
-            copyAssetTree(assetPath, tempDir)
-            val completionMarker = File(tempDir, EXTRACTION_COMPLETE_MARKER)
-            if (!completionMarker.createNewFile()) {
-                throw IllegalStateException(
-                    "failed to create extraction completion marker '$EXTRACTION_COMPLETE_MARKER'.",
-                )
-            }
-        } catch (error: Throwable) {
-            tempDir.deleteRecursively()
-            throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "model source unavailable: failed to extract bundled model assets for '$assetPath'.",
-                originalError = error,
-            )
-        }
-
-        targetDir.deleteRecursively()
-        if (!tempDir.renameTo(targetDir)) {
-            tempDir.deleteRecursively()
-            throw OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.CAPABILITY,
-                message = "model source unavailable: failed to install extracted model assets for '$assetPath'.",
-            )
-        }
-    }
-
-    private fun copyAssetTree(assetPath: String, targetDir: File) {
-        val assetManager = context.assets
-        val entries = assetManager.list(assetPath).orEmpty()
-        entries.forEach { entry ->
-            val childAssetPath = if (assetPath.isEmpty()) entry else "$assetPath/$entry"
-            val childEntries = assetManager.list(childAssetPath)
-            if (childEntries.isNullOrEmpty()) {
-                assetManager.open(childAssetPath).use { input ->
-                    File(targetDir, entry).outputStream().use { output -> input.copyTo(output) }
-                }
-            } else {
-                val childDir = File(targetDir, entry)
-                childDir.mkdirs()
-                copyAssetTree(childAssetPath, childDir)
-            }
-        }
-    }
-
-    /**
-     * Verifies every file named in `integrity.checksums`, not only the required-file list, so a
-     * checksum declared for the tokenizer or config file is enforced too. Files the map names but
-     * that this runtime did not resolve a path for are skipped (mirrors the Apple member); an
-     * unsupported checksum algorithm is a capability failure rather than a silently skipped check.
-     */
-    private fun verifyChecksums(directory: File, modelPackage: ModelPackage) {
-        val checksums = modelPackage.integrity?.checksums ?: return
-        for ((relativePath, expected) in checksums) {
-            val file = File(directory, relativePath)
-            if (!file.exists()) continue
-            verifyChecksum(file, relativePath, expected)
-        }
+        val text = decode(loaded, prompt, input)
+        return AndroidOnnxGenerationOutput(text = text, finishReason = FinishReason.STOP)
     }
 
     private fun formatMessages(messages: List<AndroidOnnxGenerationMessage>): String = messages.joinToString(separator = "\n") { "${it.role.rawValue}: ${it.content}" }
 
-    private suspend fun decode(session: LoadedSession, prompt: String, input: AndroidOnnxGenerationInput): String {
+    private suspend fun decode(loaded: LoadedSession, prompt: String, input: AndroidOnnxGenerationInput): String {
         val maxNewTokens = (input.generation?.maxOutputTokens ?: DEFAULT_MAX_NEW_TOKENS).toInt()
         val stopSequences = input.generation?.stop.orEmpty().filter { it.isNotEmpty() }
+        val sampling = SamplingConfig(input.generation)
 
-        val encoding = session.tokenizer.encode(prompt)
-        val ids = encoding.ids.toMutableList()
+        val promptTokenIds = loaded.tokenizer.encode(prompt).ids.toList()
+        val decoder = makeDecoder(loaded, promptTokenIds, maxNewTokens)
         val generatedIds = mutableListOf<Long>()
         var matchedStop: String? = null
 
         while (generatedIds.size < maxNewTokens) {
             coroutineContext.ensureActive()
 
-            val sequenceLength = ids.size
-            val inputIds = LongBuffer.wrap(ids.toLongArray())
-            val attentionMask = LongBuffer.wrap(LongArray(sequenceLength) { 1L })
-            val shape = longArrayOf(1, sequenceLength.toLong())
-
-            val nextTokenId = OnnxTensor.createTensor(session.environment, inputIds, shape).use { inputIdsTensor ->
-                OnnxTensor.createTensor(session.environment, attentionMask, shape).use { attentionMaskTensor ->
-                    session.session.run(
-                        mapOf("input_ids" to inputIdsTensor, "attention_mask" to attentionMaskTensor),
-                    ).use { result ->
-                        argmaxLastToken(result)
-                    }
-                }
-            }
-
-            ids += nextTokenId
+            val nextTokenId = decoder.step(sampling)
             generatedIds += nextTokenId
 
-            if (isEosToken(nextTokenId, session.eosTokenId)) {
+            if (isEosToken(nextTokenId, loaded.eosTokenId)) {
                 break
             }
 
-            val decodedSoFar = session.tokenizer.decode(generatedIds.toLongArray(), true)
-            val stop = matchStopSequence(decodedSoFar, stopSequences)
-            if (stop != null) {
-                matchedStop = stop
-                break
+            if (stopSequences.isNotEmpty()) {
+                val decodedSoFar = loaded.tokenizer.decode(generatedIds.toLongArray(), true)
+                val stop = matchStopSequence(decodedSoFar, stopSequences)
+                if (stop != null) {
+                    matchedStop = stop
+                    break
+                }
             }
         }
 
-        var text = session.tokenizer.decode(generatedIds.toLongArray(), true)
+        var text = loaded.tokenizer.decode(generatedIds.toLongArray(), true)
         if (matchedStop != null && text.endsWith(matchedStop)) {
             text = text.removeSuffix(matchedStop)
         }
         return text
     }
 
-    private fun argmaxLastToken(result: OrtSession.Result): Long {
-        val logitsTensor = result.get("logits").orElseThrow {
-            OnnxRuntimeError(
-                kind = OnnxRuntimeErrorKind.INTERNAL_FAILURE,
-                message = "model output malformed: session output does not contain a 'logits' tensor.",
-            )
-        } as OnnxTensor
-
-        @Suppress("UNCHECKED_CAST")
-        val logits = logitsTensor.value as Array<Array<FloatArray>>
-        val lastStepLogits = logits[0].last()
-        var bestIndex = 0
-        var bestValue = Float.NEGATIVE_INFINITY
-        for (index in lastStepLogits.indices) {
-            if (lastStepLogits[index] > bestValue) {
-                bestValue = lastStepLogits[index]
-                bestIndex = index
-            }
-        }
-        return bestIndex.toLong()
-    }
-
-    /**
-     * Resolves the tokenizer's end-of-sequence token id from the model config JSON's
-     * `eos_token_id` field (a plain integer, or the first entry when the field is a list, per the
-     * Hugging Face `config.json` convention). The DJL tokenizer binding does not expose special
-     * token ids directly, unlike `swift-transformers` on Apple, so this runtime reads the config
-     * file itself. Absence of a resolvable config or field means generation relies solely on
-     * `generation.stop`/`maxOutputTokens`, not on EOS detection.
-     */
-    private fun resolveEosTokenId(directory: File, modelPackage: ModelPackage): Long? {
-        val configFile = modelPackage.files?.config?.let { File(directory, it) }
-            ?: File(directory, "config.json").takeIf { it.exists() }
-            ?: return null
-        if (!configFile.exists()) return null
-
-        return try {
-            parseEosTokenId(configFile.readText())
-        } catch (error: Throwable) {
-            null
-        }
-    }
-
-    private fun sessionCacheKey(modelPackage: ModelPackage): String {
-        val checksums = modelPackage.integrity?.checksums?.entries
-            ?.sortedBy { it.key }
-            ?.joinToString(separator = ",") { "${it.key}=${it.value}" }
-            .orEmpty()
-        return listOf(
-            modelPackage.id,
-            modelPackage.format.name,
-            modelPackage.version.orEmpty(),
-            modelPackage.source?.sourceType?.name.orEmpty(),
-            modelPackage.source?.ref.orEmpty(),
-            checksums,
-        ).joinToString(separator = "|")
-    }
-
-    private data class LoadedSession(
-        val cacheKey: String,
-        val environment: OrtEnvironment,
-        val session: OrtSession,
-        val tokenizer: HuggingFaceTokenizer,
-        val eosTokenId: Long?,
-    ) {
-        fun close() {
-            session.close()
-            tokenizer.close()
-        }
+    private fun makeDecoder(loaded: LoadedSession, promptTokenIds: List<Long>, maxOutputTokens: Int): StepDecoder = when (val strategy = loaded.decodeStrategy) {
+        is DecodeStrategy.FullRecompute -> FullRecomputeDecoder(loaded, promptTokenIds, maxOutputTokens)
+        is DecodeStrategy.KvCache -> KvCacheDecoder(loaded, strategy.layout, promptTokenIds)
     }
 
     private companion object {
         const val DEFAULT_MAX_NEW_TOKENS = 256L
-        const val EXTRACTION_COMPLETE_MARKER = ".inderun-onnx-extraction-complete"
     }
 }
 
@@ -420,64 +136,3 @@ internal fun isEosToken(tokenId: Long, eosTokenId: Long?): Boolean = eosTokenId 
 
 /** Returns the first `generation.stop` sequence the decoded-so-far text ends with, or `null`. */
 internal fun matchStopSequence(decodedSoFar: String, stopSequences: List<String>): String? = stopSequences.firstOrNull { decodedSoFar.endsWith(it) }
-
-/**
- * Verifies a single resolved file against a `algorithm:hex` checksum string. Only `sha256` is
- * supported; any other algorithm prefix is a capability failure rather than a silently skipped
- * check, since the schema permits arbitrary non-empty checksum strings and a configured-but-unknown
- * algorithm must not be mistaken for "no integrity check requested".
- */
-internal fun verifyChecksum(file: File, relativePath: String, expected: String) {
-    val prefix = "sha256:"
-    if (!expected.startsWith(prefix, ignoreCase = true)) {
-        throw OnnxRuntimeError(
-            kind = OnnxRuntimeErrorKind.CAPABILITY,
-            message = "checksum/integrity mismatch: unsupported checksum algorithm for '$relativePath' " +
-                "(only 'sha256:<hex>' is supported).",
-        )
-    }
-
-    val digest = MessageDigest.getInstance("SHA-256")
-    file.inputStream().use { input ->
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        var read = input.read(buffer)
-        while (read >= 0) {
-            digest.update(buffer, 0, read)
-            read = input.read(buffer)
-        }
-    }
-    val actual = digest.digest().joinToString(separator = "") { "%02x".format(it) }
-    val expectedHex = expected.substring(prefix.length)
-    if (!actual.equals(expectedHex, ignoreCase = true)) {
-        throw OnnxRuntimeError(
-            kind = OnnxRuntimeErrorKind.CAPABILITY,
-            message = "checksum/integrity mismatch: '$relativePath' does not match the expected checksum.",
-        )
-    }
-}
-
-/**
- * Extracts `eos_token_id` from a Hugging Face-style `config.json` payload. The field is either a
- * plain integer or a list of integers (some model configs declare multiple eos candidates); the
- * first value is used either way. Returns `null` when the field is absent or malformed.
- */
-internal fun parseEosTokenId(configJson: String): Long? {
-    val json = JSONObject(configJson)
-    if (!json.has("eos_token_id")) return null
-
-    val value = json.get("eos_token_id")
-    return when (value) {
-        is Int -> value.toLong()
-        is Long -> value
-        is org.json.JSONArray -> if (value.length() > 0) value.getLong(0) else null
-        else -> null
-    }
-}
-
-/** Short, filesystem-safe digest of a session cache key, used to key extracted-asset directories
- * so a changed model identity (version/source/checksums) extracts into a fresh directory instead
- * of reusing stale bytes copied under an older identity. */
-internal fun cacheKeyDigest(cacheKey: String): String {
-    val digest = MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray(Charsets.UTF_8))
-    return digest.joinToString(separator = "") { "%02x".format(it) }.take(16)
-}

--- a/android/inderun-onnx-providers/src/test/kotlin/app/independo/inderun/providers/onnx/OnnxSamplingTest.kt
+++ b/android/inderun-onnx-providers/src/test/kotlin/app/independo/inderun/providers/onnx/OnnxSamplingTest.kt
@@ -1,0 +1,39 @@
+package app.independo.inderun.providers.onnx
+
+import app.independo.inderun.contracts.Generation
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OnnxSamplingTest {
+
+    @Test
+    fun selectTokenIsDeterministicArgmaxWithoutTemperature() {
+        val sampling = SamplingConfig(generation = null)
+        val logits = floatArrayOf(0.1f, 5.0f, -2.0f, 3.0f)
+
+        assertEquals(1L, sampling.selectToken(logits))
+    }
+
+    @Test
+    fun selectTokenWithSeedIsReproducibleAcrossInstances() {
+        val generation = Generation(seed = 42L, temperature = 0.8)
+        val logits = floatArrayOf(1.0f, 2.0f, 3.0f, 0.5f, 4.0f)
+
+        val first = SamplingConfig(generation).selectToken(logits)
+        val second = SamplingConfig(generation).selectToken(logits)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun selectTokenWithTopPNarrowsToDominantCandidate() {
+        // A single overwhelmingly likely logit plus low-probability noise: after softmax and a
+        // tight topP, only the dominant index should remain in the candidate set regardless of
+        // the (seeded, reproducible) random draw.
+        val generation = Generation(seed = 7L, temperature = 1.0, topP = 0.5)
+        val logits = floatArrayOf(-10f, -10f, 20f, -10f, -10f)
+
+        val sampling = SamplingConfig(generation)
+        assertEquals(2L, sampling.selectToken(logits))
+    }
+}

--- a/android/inderun-onnx-providers/src/test/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoadingKvCacheDetectionTest.kt
+++ b/android/inderun-onnx-providers/src/test/kotlin/app/independo/inderun/providers/onnx/OnnxSessionLoadingKvCacheDetectionTest.kt
@@ -1,0 +1,100 @@
+package app.independo.inderun.providers.onnx
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class OnnxSessionLoadingKvCacheDetectionTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun detectDecodeStrategyFallsBackToFullRecomputeWithoutPastKeyValuesInputs() {
+        val strategy = detectDecodeStrategy(
+            inputNames = setOf("input_ids", "attention_mask"),
+            outputNames = setOf("logits"),
+            directory = tempFolder.root,
+        )
+
+        assertEquals(DecodeStrategy.FullRecompute, strategy)
+    }
+
+    @Test
+    fun detectDecodeStrategySelectsKvCacheWhenEveryAssumptionResolves() {
+        writeConfig(numHiddenLayers = 2, numAttentionHeads = 4, hiddenSize = 32)
+        val inputNames = kvCacheInputNames(numLayers = 2) + setOf("input_ids", "attention_mask", "position_ids")
+        val outputNames = kvCachePresentOutputNames(numLayers = 2) + setOf("logits")
+
+        val strategy = detectDecodeStrategy(inputNames, outputNames, tempFolder.root)
+
+        assertTrue(strategy is DecodeStrategy.KvCache)
+        val layout = (strategy as DecodeStrategy.KvCache).layout
+        assertEquals(2, layout.numLayers)
+        assertEquals(4, layout.numKeyValueHeads)
+        assertEquals(8, layout.headDim)
+        assertTrue(layout.hasPositionIds)
+    }
+
+    @Test
+    fun detectDecodeStrategyFallsBackWhenConfigJsonMissing() {
+        val inputNames = kvCacheInputNames(numLayers = 1) + setOf("input_ids", "attention_mask")
+        val outputNames = kvCachePresentOutputNames(numLayers = 1) + setOf("logits")
+
+        val strategy = detectDecodeStrategy(inputNames, outputNames, tempFolder.root)
+
+        assertEquals(DecodeStrategy.FullRecompute, strategy)
+    }
+
+    @Test
+    fun detectDecodeStrategyFallsBackWhenPresentOutputMissing() {
+        writeConfig(numHiddenLayers = 1, numAttentionHeads = 2, hiddenSize = 16)
+        val inputNames = kvCacheInputNames(numLayers = 1) + setOf("input_ids", "attention_mask")
+        val outputNames = setOf("logits") // missing present.0.key/value
+
+        val strategy = detectDecodeStrategy(inputNames, outputNames, tempFolder.root)
+
+        assertEquals(DecodeStrategy.FullRecompute, strategy)
+    }
+
+    @Test
+    fun detectDecodeStrategyFallsBackForMergedUseCacheBranchGraphs() {
+        writeConfig(numHiddenLayers = 1, numAttentionHeads = 2, hiddenSize = 16)
+        val inputNames = kvCacheInputNames(numLayers = 1) + setOf("input_ids", "attention_mask", "use_cache_branch")
+        val outputNames = kvCachePresentOutputNames(numLayers = 1) + setOf("logits")
+
+        val strategy = detectDecodeStrategy(inputNames, outputNames, tempFolder.root)
+
+        assertEquals(DecodeStrategy.FullRecompute, strategy)
+    }
+
+    @Test
+    fun detectDecodeStrategyReadsGpt2StyleConfigFieldNames() {
+        writeConfig(numHiddenLayers = null, numAttentionHeads = null, hiddenSize = null, extra = """"n_layer": 1, "n_head": 2, "n_embd": 16""")
+        val inputNames = kvCacheInputNames(numLayers = 1) + setOf("input_ids", "attention_mask")
+        val outputNames = kvCachePresentOutputNames(numLayers = 1) + setOf("logits")
+
+        val strategy = detectDecodeStrategy(inputNames, outputNames, tempFolder.root)
+
+        assertTrue(strategy is DecodeStrategy.KvCache)
+        val layout = (strategy as DecodeStrategy.KvCache).layout
+        assertEquals(1, layout.numLayers)
+        assertEquals(2, layout.numKeyValueHeads)
+        assertEquals(8, layout.headDim)
+    }
+
+    private fun kvCacheInputNames(numLayers: Int): Set<String> = (0 until numLayers).flatMap { layer -> listOf("past_key_values.$layer.key", "past_key_values.$layer.value") }.toSet()
+
+    private fun kvCachePresentOutputNames(numLayers: Int): Set<String> = (0 until numLayers).flatMap { layer -> listOf("present.$layer.key", "present.$layer.value") }.toSet()
+
+    private fun writeConfig(numHiddenLayers: Int?, numAttentionHeads: Int?, hiddenSize: Int?, extra: String? = null) {
+        val fields = mutableListOf<String>()
+        numHiddenLayers?.let { fields += """"num_hidden_layers": $it""" }
+        numAttentionHeads?.let { fields += """"num_attention_heads": $it""" }
+        hiddenSize?.let { fields += """"hidden_size": $it""" }
+        extra?.let { fields += it }
+        tempFolder.newFile("config.json").writeText("{${fields.joinToString(separator = ",")}}")
+    }
+}

--- a/docs/architecture/onnx-runtime-provider-family.md
+++ b/docs/architecture/onnx-runtime-provider-family.md
@@ -67,13 +67,18 @@ runs ONNX models on `onnxruntime-web` and owns the generative loop. Source:
 
 **Correction — the mobile members target raw ORT Mobile, not the ORT GenAI package.** Both shipped
 mobile members (Apple, Android) default to the platform's raw ONNX Runtime Mobile bindings plus a
-hand-written greedy decode loop and an external tokenizer, rather than
+hand-written decode loop and an external tokenizer, rather than
 `onnxruntime-genai`/`onnxruntime-extensions`. This keeps both defaults on the same well-established,
-non-preview API surface used by the Web member's underlying runtime, at the documented cost of no
-KV-cache reuse and CPU-only execution (see the platform sections below). This is exactly what the
-injectable seam exists for: the seam is the contract, and any application (or a future IndeRun
-default) can supply an ORT-GenAI-backed `OnnxGenAiRuntime`/`AndroidOnnxGenAiRuntime` implementation
-without changing the provider.
+non-preview API surface used by the Web member's underlying runtime. Both mobile members now
+auto-detect and reuse `past_key_values`/KV-cache export shapes where the graph and `config.json`
+support it (falling back to full-sequence recompute otherwise) and configure an accelerated
+execution provider (CoreML/XNNPACK on Apple, NNAPI/XNNPACK on Android) with a CPU fallback — this is
+no longer a blanket "no KV-cache reuse, CPU-only" limitation, though none of it has been exercised
+against a real model on a real device beyond the plain-path verification noted in each platform
+section (#88). This is exactly what the injectable seam exists for regardless: the seam is the
+contract, and any application (or a future IndeRun default) can supply an
+ORT-GenAI-backed `OnnxGenAiRuntime`/`AndroidOnnxGenAiRuntime` implementation without changing the
+provider.
 
 **Deterministic fixture fallback.** IndeRun already makes on-device adapters testable without their
 native backend via an injectable runtime interface (`AppleFoundationModelsRuntime`,
@@ -447,31 +452,99 @@ the Web member's explicit `AbortSignal` parameter). Two implementations exist:
 - `SystemAndroidOnnxGenAiRuntime(context)` — the default. Runs inference through ONNX Runtime
   Mobile's Java bindings (`com.microsoft.onnxruntime:onnxruntime-android`) and tokenizes with a
   Hugging Face tokenizer (`ai.djl.huggingface:tokenizers` plus its Android native binding,
-  `ai.djl.android:tokenizer-native`). **IO contract**: identical to the Apple member — the model
-  graph must expose exactly `input_ids` and `attention_mask` inputs (`int64`, `[1,
-sequenceLength]`) and a `logits` output (`float32`, `[1, sequenceLength, vocabSize]`), the plain
-  decoder-only export shape without `past_key_values`. **Graph file convention**: same as Apple —
-  `ModelPackage.files.required`'s _first_ entry is the ONNX graph file; remaining entries (for
-  example external weight shards) must be present alongside it. Every file named in
-  `ModelPackage.integrity.checksums` is verified before load, not only the required-file list;
-  an algorithm prefix other than `sha256:` is a capability failure rather than a silently skipped
-  check. The session cache key covers `id`, `format`, `version`, `source`, and
-  `integrity.checksums` together, not `id` alone. **Stop conditions**: generation stops on the
-  tokenizer's end-of-sequence token — resolved from the model config JSON's `eos_token_id` field,
-  since the DJL tokenizer binding does not expose special token ids the way `swift-transformers`
-  does on Apple — on a `generation.stop` suffix match, or once `maxOutputTokens` is reached,
-  whichever comes first; cancellation is checked before every decode step. Decoding is **greedy
-  (argmax) with no KV-cache reuse**: the full sequence is recomputed on every generated token, CPU
-  execution provider only — no NNAPI or XNNPACK acceleration configured. This is a real, documented
-  performance limitation, not a hidden one. `temperature`/`topP`/`seed` are not honored (no
-  sampling, argmax only). Unlike the Apple and Web members,
-  this default runtime does **not** attempt chat-template application — Hugging Face chat-template
-  support in the Android tokenizer binding is not guaranteed across models, so it falls back
-  unconditionally to a plain `"role: content"` join; apps that need chat templates, sampling, an
-  accelerated execution provider, or a KV-cached decode loop supply their own
-  `AndroidOnnxGenAiRuntime`. `programmatic` model sources are out of scope for this default runtime
-  (no files to resolve, matching the Web/Apple members' own `programmatic` carve-out); it reports
-  _runtime package unavailable_ rather than throwing. **Native dependency**: `ai.djl.android:tokenizer-native`'s
+  `ai.djl.android:tokenizer-native`). Implemented across several files by concern, mirroring the
+  Apple member's own split (`SystemOnnxGenAiRuntime.swift` + `OnnxSessionLoading*.swift` +
+  `OnnxSampling.swift` + `OnnxTensorExecution.swift` + `SystemOnnxGenAiRuntime+Decoders.swift`):
+  `SystemAndroidOnnxGenAiRuntime.kt` (orchestration), `OnnxSessionLoading.kt` (session/tokenizer/EP
+  loading, asset extraction, checksums), `OnnxSessionLoadingKvCacheDetection.kt` (decode-strategy
+  detection), `OnnxDecoders.kt` (the two decode-step strategies below), `OnnxSampling.kt`
+  (temperature/top-p/seed sampling), and `OnnxTensorExecution.kt` (the dedicated dispatcher and
+  `OrtException`-wrapping run helper).
+
+  **IO contract**: this runtime auto-detects, from the loaded graph's declared input names, which
+  of two decoder-only export shapes a model uses — no `ModelPackage` field or app-facing
+  configuration selects it, identical in spirit to the Apple member's detection:
+  - **Plain** (no `past_key_values.*` inputs): shape `[1, sequenceLength]`, the full sequence
+    recomputed every decode step. Always supported; the fallback whenever KV-cache detection can't
+    establish every assumption below.
+  - **KV-cache** (`past_key_values.{layer}.key`/`.value` inputs present, the legacy (non-merged)
+    Hugging Face Optimum `decoder_with_past_model` export convention): exactly one token is fed as
+    `input_ids` per model call — this graph shape traces `input_ids`'s sequence-length axis fixed
+    at 1, so the prompt is replayed through the same session one token at a time (discarding
+    logits) to build up `past_key_values` before the first real generated token, then generation
+    proceeds one token per call the same way, with each call's `present.{layer}.key`/`.value`
+    outputs threaded back in as the next call's `past_key_values.*` inputs directly (no copy).
+    Detection additionally requires `num_hidden_layers` (or GPT-2-style `n_layer`),
+    `num_attention_heads`/`n_head` (or `num_key_value_heads` for GQA models), and
+    `hidden_size`/`n_embd` (or an explicit `head_dim`) to be readable from `config.json`, and every
+    expected `past_key_values.{layer}.{key,value}` input / `present.{layer}.{key,value}` output to
+    be present by that naming convention; an optional `position_ids` input is fed the running
+    absolute position when the graph declares it. Graphs that instead declare a `use_cache_branch`
+    boolean input (merged Optimum exports) fall back to the plain path — this runtime does not
+    implement the merged graph's alternate calling convention. Detection is deliberately
+    conservative — any unresolvable assumption falls back to the plain path rather than guessing —
+    and, like the rest of this default runtime, has not been exercised against a real KV-cache
+    export on an Android device; that remains part of #88, mirroring the Apple member's own
+    real-device carve-out (the Apple member's equivalent path *was* corrected against a real device
+    failure on LaMini-GPT — the Android path is unverified, not merely undocumented).
+
+  **Graph file convention**: same as Apple — `ModelPackage.files.required`'s _first_ entry is the
+  ONNX graph file; remaining entries (for example external weight shards) must be present alongside
+  it. Every file named in `ModelPackage.integrity.checksums` is verified before load, not only the
+  required-file list; an algorithm prefix other than `sha256:` is a capability failure rather than a
+  silently skipped check. The session cache key covers `id`, `format`, `version`, `source`, and
+  `integrity.checksums` together, not `id` alone.
+
+  **Execution.** `OrtEnvironment.getEnvironment()` already returns a process-wide singleton per its
+  own Java API contract, so — unlike the Apple member's `ORTEnv`, which needed an explicit
+  shared-instance wrapper — no separate wrapper is needed here; every session reuses the same
+  environment instance as-is. Session creation and every `run()` call execute on a dedicated
+  single-thread `CoroutineDispatcher` rather than `Dispatchers.IO`/`Dispatchers.Default`, since
+  `OrtSession.run()` and session construction are blocking synchronous calls. The NNAPI execution
+  provider is configured by default on the plain decode path (`SessionOptions.addNnapi()`), falling
+  back to XNNPACK (`addXnnpack`) and then ORT's default CPU EP if NNAPI configuration fails on the
+  host; `setIntraOpNumThreads` is set explicitly, bounded by the device's available processor
+  count, rather than left at ORT's implicit default. **The KV-cache path never uses NNAPI**,
+  regardless of host availability: its first decode call feeds a genuinely zero-length
+  `past_key_values` tensor, and the Apple member's CoreML EP is documented to reject an analogous
+  zero-length dynamic-shaped input at run time on a real device — this runtime applies the same
+  conservative rule to NNAPI on the same reasoning, but whether NNAPI actually rejects it the same
+  way is an unverified assumption carried over from the Apple finding, not a confirmed
+  Android-device result (#88). Since ORT's execution provider list is fixed at session-creation
+  time, that graph's session is created directly on XNNPACK/CPU. The plain decode path preallocates
+  its `input_ids`/`attention_mask` buffers once per generation, as direct `LongBuffer`s sized to
+  `promptLength + maxOutputTokens`, and writes into a growing subrange each step rather than
+  allocating a fresh buffer per token; the KV-cache path's `past_key_values` reuse (above) is itself
+  the buffer-reuse win for that path.
+
+  **Decoding** defaults to greedy (argmax). Setting `generation.temperature` switches to sampling:
+  logits are scaled by `1 / temperature`, optionally narrowed to the smallest token set whose
+  cumulative probability reaches `generation.topP` (nucleus sampling), then sampled — seeded
+  (reproducibly) via `kotlin.random.Random(seed)` when `generation.seed` is set, natively seedable
+  unlike the Apple member's `SystemRandomNumberGenerator` (which needed a custom `SplitMix64`).
+  `generation.stop` sequences are honored on both decode paths. **Stop conditions**: generation
+  stops on the tokenizer's end-of-sequence token — resolved from the model config JSON's
+  `eos_token_id` field, since the DJL tokenizer binding does not expose special token ids the way
+  `swift-transformers` does on Apple — on a `generation.stop` suffix match, or once
+  `maxOutputTokens` is reached, whichever comes first; cancellation is checked before every decode
+  step.
+
+  Unlike the Apple and Web members, this default runtime does **not** attempt chat-template
+  application: `ai.djl.huggingface:tokenizers` (`0.33.0`) exposes no `applyChatTemplate`-equivalent
+  API or special-token accessor on its public `HuggingFaceTokenizer` surface — this is a verified,
+  permanent gap for this runtime, not an oversight pending evaluation, and it falls back
+  unconditionally to a plain `"role: content"` join. Apps that need chat templates, an execution
+  provider/sampling strategy this runtime doesn't configure, or a KV-cache export shape this runtime
+  doesn't auto-detect (for example `use_cache_branch`-gated merged graphs) supply their own
+  `AndroidOnnxGenAiRuntime`; real-device verification (load time, token latency, peak memory,
+  cancellation behavior, repeated-run stability against an actual model, for both decode paths, and
+  whether NNAPI actually degrades on the KV-cache path's zero-length tensor the way CoreML does) is
+  tracked in #88 — this default has not yet been run against a real model on-device beyond the
+  plain-path DistilGPT-2 verification below. `programmatic` model sources are out of scope for this
+  default runtime (no files to resolve, matching the Web/Apple members' own `programmatic`
+  carve-out); it reports _runtime package unavailable_ rather than throwing.
+
+  **Native dependency**: `ai.djl.android:tokenizer-native`'s
   prebuilt `libdjl_tokenizer.so` dynamically links `libc++_shared.so`, but the artifact does not
   bundle it — an app that depends on `inderun-onnx-providers` and doesn't separately provide
   `libc++_shared.so` for every targeted ABI fails the first tokenizer load with
@@ -484,9 +557,11 @@ sequenceLength]`) and a `logits` output (`float32`, `[1, sequenceLength, vocabSi
   it — no binary committed to source control, sourced from the module's declared `ndkVersion`
   instead. This was found and fixed via real-device
   verification on an Android emulator (arm64-v8a, API 34): the default runtime downloads, loads,
-  and generates text from a real DistilGPT-2 ONNX export end-to-end (load time, token latency, and
-  repeated-run stability were not separately profiled — that remains a follow-up, matching the
-  Apple member's own #88 carve-out).
+  and generates text from a real DistilGPT-2 ONNX export end-to-end on the plain (no-KV-cache,
+  no-sampling) decode path (load time, token latency, and repeated-run stability were not
+  separately profiled — that remains a follow-up, matching the Apple member's own #88 carve-out).
+  The EP configuration, KV-cache decode path, and sampling added since have not themselves been
+  re-verified against that or any other real device.
 - `createFixtureOnnxRuntime(options)` — the deterministic in-memory fixture mandated above,
   public/importable like the Web and Apple members' fixtures.
 - Any application-supplied implementation of `AndroidOnnxGenAiRuntime`.

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
@@ -137,7 +137,7 @@ public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
     private func encodeInput(_ messages: [OnnxGenerationMessage], tokenizer: Tokenizer) -> [Int] {
         let chatMessages: [[String: any Sendable]] = messages.map { ["role": $0.role.rawValue, "content": $0.content] }
         if let tokenIds = try? tokenizer.applyChatTemplate(messages: chatMessages) {
-            return tokenIds
+        return tokenIds
         }
         return tokenizer.encode(text: normalizedPrompt(from: messages))
     }


### PR DESCRIPTION
## Summary
- Implements #127, mirroring the Apple member's #126 (PR #131 / db704de): NNAPI EP with XNNPACK/CPU fallback, dedicated single-thread dispatcher for blocking `OrtSession` calls, buffer reuse in the full-recompute decode path, auto-detected KV-cache decode path (legacy Optimum `decoder_with_past` convention), and temperature/topP/seed sampling in `SystemAndroidOnnxGenAiRuntime`.
- Splits the file by concern in the same pass (session loading, KV-cache detection, decoders, sampling, tensor execution) so it never lands in an unreviewable single-file state, matching PR #131's Apple-side split. Main class: 483 → 138 lines.
- `OrtEnvironment.getEnvironment()` is already a process-wide singleton, so no shared-instance wrapper was needed here unlike the Apple member's `ORTEnv`.
- Chat-template application remains unimplemented: `ai.djl.huggingface:tokenizers` `0.33.0` has no `applyChatTemplate`-equivalent API, confirmed via its public class surface — closes that item as a verified permanent gap, not a pending evaluation.
- Updates `docs/architecture/onnx-runtime-provider-family.md`'s Android Implementation section and the stale "no KV-cache/CPU-only" framing near the top of the doc.

## Test plan
- [x] `./gradlew :inderun-onnx-providers:test` (existing tests + new `OnnxSamplingTest`, `OnnxSessionLoadingKvCacheDetectionTest`)
- [x] `./gradlew :inderun-onnx-providers:spotlessCheck`
- [x] `./gradlew :inderun-demo-app:compileDebugKotlin` (public API unchanged, demo app unaffected)
- [ ] Real-device/model verification — out of scope here, tracked in #88 (same carve-out as the Apple member)

🤖 Generated with [Claude Code](https://claude.com/claude-code)