### PR TITLE
docs: align provider docs with implementation, close #84/#88, align R…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,14 +26,15 @@ Treat them as the architecture baseline.
 
 ## 3) Scope Boundaries (Current Phase)
 
-In scope now (Milestone 1 — Text→Text MVP):
+Milestone planning, scope, and status live in GitHub Issues and Milestones
+(https://github.com/independo-gmbh/inderun/milestones), not in this file. Check
+there for what's currently in scope before starting work — do not infer scope
+from this document or assume it is up to date.
 
-- Mode 1: `run()` for `text_to_text`
-
-Future (Milestone 2), not yet implemented:
-
-- Mode 2: `stream()` + cancellation semantics
-- Mode 3: `openSession()` / realtime session model
+As of this writing, Mode 1 `run()` is implemented and stable, and provider
+breadth (ONNX Runtime, web system-model) has landed. Mode 2 `stream()` +
+cancellation semantics and Mode 3 `openSession()` / realtime sessions remain
+unimplemented.
 
 Out of scope now:
 
@@ -181,6 +182,26 @@ When behavior or contracts change, update docs in the same task:
 - provider semantics/capabilities: `docs/architecture/providers.md`
 - project framing/scope: `docs/architecture/technical-brief.md`
 - CI/process behavior: `docs/ci.md`
+
+Any change that adds a provider, changes a provider's capability check, task
+support, interaction modes, cancellation behavior, or error mapping MUST update
+the [Provider Matrix](docs/architecture/providers.md#provider-matrix) row for
+that provider (and the family-specific doc, if one exists) in the same task.
+
+**Where technical detail belongs.** `docs/architecture/*.md` files are for durable,
+high-level information: concepts, boundaries, contracts, public type/function
+names, and rationale that doesn't change with routine implementation work. They
+are not the place for algorithm walkthroughs, exact control-flow/gate ordering,
+buffer/threading strategy, or other detail that lives next to the code it
+describes — that content drifts out of sync with the implementation almost
+immediately, and belongs in code comments (doc comments on the relevant
+type/function) or a package-level README instead. When writing or reviewing an
+architecture doc, if a sentence would need to change every time someone edits the
+function it's describing, move it into a comment at that function instead of
+stating it in prose here — the doc should then just name the function and link to
+its directory. See `docs/architecture/onnx-runtime-provider-family.md`'s
+"Implementation detail... lives in code comments in [directory]" sections for the
+pattern.
 
 If the change is material and docs are not updated, the task is incomplete.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
   <a href="https://github.com/independo-gmbh/inderun/actions/workflows/rust.yml"><img alt="Rust" src="https://github.com/independo-gmbh/inderun/actions/workflows/rust.yml/badge.svg?branch=dev"></a>
   <a href="https://github.com/independo-gmbh/inderun/actions/workflows/swift.yml"><img alt="Swift" src="https://github.com/independo-gmbh/inderun/actions/workflows/swift.yml/badge.svg?branch=dev"></a>
   <a href="https://github.com/independo-gmbh/inderun/actions/workflows/android.yml"><img alt="Android" src="https://github.com/independo-gmbh/inderun/actions/workflows/android.yml/badge.svg?branch=dev"></a>
-  <a href="https://github.com/independo-gmbh/inderun/actions/workflows/capacitor.yml"><img alt="Capacitor Plugin" src="https://github.com/independo-gmbh/inderun/actions/workflows/capacitor.yml/badge.svg?branch=dev"></a>
 </p>
 
 <p align="center">
@@ -32,9 +31,10 @@ The project is organized around a few stable ideas:
 ## Status
 
 IndeRun is currently focused on Mode 1 `run()` execution for `text_to_text`. Streaming and realtime sessions are
-planned (Milestone 2) but not yet implemented; the shipped surface is request/response execution. Every platform can
-always use the OpenAI-compatible **cloud** provider; **on-device** execution is used automatically by routing when the
-device supports it (or forced with a `localRequired` privacy constraint).
+planned but not yet implemented; the shipped surface is request/response execution. Every platform can always use the
+OpenAI-compatible **cloud** provider; **on-device** execution is used automatically by routing when the device
+supports it (or forced with a `localRequired` privacy constraint). See
+[GitHub Milestones](https://github.com/independo-gmbh/inderun/milestones) for current roadmap status.
 
 ## Platforms
 
@@ -161,9 +161,8 @@ val result = indeRun.run(
 
 ### Capacitor (hybrid apps)
 
-A thin Capacitor bridge (`@independo/capacitor-inderun`) delegates to the native iOS and Android SDKs. It lives in its
-own, SwiftPM-publishable repository — **[independo-gmbh/inderun-capacitor](https://github.com/independo-gmbh/inderun-capacitor)** —
-and consumes the SDKs published from this monorepo (npm, SwiftPM git tag, Maven Central). See that repo for install and usage.
+A thin Capacitor bridge is used internally to integrate the native iOS and Android SDKs into hybrid applications. It
+is not currently published as a public package or repository.
 
 ## Minimum system requirements
 
@@ -210,3 +209,5 @@ MIT. See `LICENSE`.
 
 This project is sponsored by [netidee](https://www.netidee.at/inderun) and developed
 by [Independo GmbH](https://www.independo.app).
+
+Explore more [open-source tools and research from Independo](https://www.independo.app/open-source).

--- a/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/SystemAndroidOnnxGenAiRuntime.kt
+++ b/android/inderun-onnx-providers/src/main/kotlin/app/independo/inderun/providers/onnx/SystemAndroidOnnxGenAiRuntime.kt
@@ -12,50 +12,19 @@ import kotlin.coroutines.coroutineContext
  * (`com.microsoft.onnxruntime:onnxruntime-android`) and a Hugging Face tokenizer
  * (`ai.djl.huggingface:tokenizers`).
  *
- * **IO contract**: this runtime auto-detects, from the loaded graph's declared input names, which
- * of two decoder-only export shapes a model uses -- no [ModelPackage] field or app-facing
- * configuration selects it (see [detectDecodeStrategy] in `OnnxSessionLoadingKvCacheDetection.kt`).
- * Both require `input_ids`/`attention_mask` (`int64`) and a `logits` output (`float32`, `[1,
- * sequenceLength, vocabSize]`):
- *
- * - **Plain** (no `past_key_values.*` inputs, [DecodeStrategy.FullRecompute]): the full sequence
- *   is recomputed on every decode step. Always supported; the fallback when KV-cache detection
- *   can't establish every assumption below.
- * - **KV-cache** ([DecodeStrategy.KvCache], matching the legacy (non-merged) Hugging Face Optimum
- *   `decoder_with_past_model` export convention): exactly one token is fed as `input_ids` per
- *   model call, the prompt replayed one token at a time first. Requires `num_hidden_layers` (or
- *   GPT-2-style `n_layer`), `num_attention_heads`/`n_head` (or `num_key_value_heads`), and
- *   `hidden_size`/`n_embd` (or `head_dim`) to be readable from `config.json`. Mirrors the Apple
- *   member's `KvCacheDecoder`; see `OnnxDecoders.kt`.
- *
- * **Decode loop.** Generation defaults to greedy (argmax); `generation.temperature`/`topP`/`seed`
- * select sampling instead (see `OnnxSampling.kt`). `generation.stop` sequences are honored. Session
- * creation and every `run()` call execute on a dedicated single-thread dispatcher rather than
- * [kotlinx.coroutines.Dispatchers.IO]/[kotlinx.coroutines.Dispatchers.Default], since
- * `OrtSession.run()` is a blocking synchronous call (`OnnxTensorExecution.kt`). `OrtEnvironment` is
- * already a process-wide singleton per its own Java API contract (`OrtEnvironment.getEnvironment()`),
- * so no separate shared-instance wrapper is needed, unlike the Apple member's `ORTEnv`. The NNAPI
- * execution provider is configured by default on the plain decode path, falling back to XNNPACK
- * and then ORT's default CPU EP if NNAPI is unavailable on the host; the KV-cache path never uses
- * NNAPI (see `OnnxSessionLoading.kt`). See
- * `docs/architecture/onnx-runtime-provider-family.md` for the full specification and residual
- * risks -- none of the above has been exercised on a real device or model; that remains #88.
- *
- * **Chat formatting.** Chat-template application is not attempted: `ai.djl.huggingface:tokenizers`
- * exposes no `applyChatTemplate`-equivalent API (verified against its `0.33.0` public surface), so
- * this is a permanent gap for this runtime, not an oversight pending evaluation -- unlike the
- * Apple/Web members. Input always falls back to a plain `"role: content"` join.
- *
- * **Bundled asset extraction.** `bundled` sources are copied from Android assets into app-private
- * storage under a directory keyed by the session cache key (id/format/version/source/checksums), so
- * a changed `version`/`ref`/checksum extracts into a fresh directory rather than silently reusing
- * stale bytes. Extraction is atomic (copied into a temp directory, marked complete, then moved into
- * place) so an interrupted copy cannot poison a later load.
+ * This type only orchestrates; the actual behavior is documented next to where it's implemented,
+ * not restated here (kept in one place to avoid the two copies drifting apart):
+ * - Decode-strategy auto-detection (plain vs. KV-cache IO contract): [detectDecodeStrategy] in
+ *   `OnnxSessionLoadingKvCacheDetection.kt`.
+ * - Session/execution-provider setup, bundled-asset extraction, and the KV-cache/NNAPI
+ *   incompatibility: `OnnxSessionLoading.kt`.
+ * - Sampling (greedy/temperature/top-p): `OnnxSampling.kt`.
+ * - The two decode-step loops: `OnnxDecoders.kt`.
+ * - Chat-template gap: [formatMessages].
  *
  * `programmatic` model sources are out of scope for this default runtime (no files to resolve,
  * matching the Web/Apple members' own `programmatic` carve-out); it reports *runtime package
- * unavailable* rather than throwing. This default runtime has not been run against a real model
- * on-device -- real-device verification is tracked alongside the Apple member's own follow-up (#88).
+ * unavailable* rather than throwing.
  */
 class SystemAndroidOnnxGenAiRuntime(context: Context) : AndroidOnnxGenAiRuntime {
 
@@ -82,6 +51,12 @@ class SystemAndroidOnnxGenAiRuntime(context: Context) : AndroidOnnxGenAiRuntime 
         return AndroidOnnxGenerationOutput(text = text, finishReason = FinishReason.STOP)
     }
 
+    /**
+     * Chat-template application is not attempted: `ai.djl.huggingface:tokenizers` exposes no
+     * `applyChatTemplate`-equivalent API (verified against its `0.33.0` public surface), so this
+     * is a permanent gap for this runtime, not an oversight pending evaluation -- unlike the
+     * Apple/Web members. Falls back unconditionally to a plain `"role: content"` join.
+     */
     private fun formatMessages(messages: List<AndroidOnnxGenerationMessage>): String = messages.joinToString(separator = "\n") { "${it.role.rawValue}: ${it.content}" }
 
     private suspend fun decode(loaded: LoadedSession, prompt: String, input: AndroidOnnxGenerationInput): String {

--- a/docs/architecture/api-surface-generation.md
+++ b/docs/architecture/api-surface-generation.md
@@ -132,13 +132,13 @@ checklist, not just a fancier one):
 
 **Streaming/session scope guard:** the illustrative idiom mapping for future
 operations (`AsyncIterable<Event>` / `Flow<Event>` / `AsyncThrowingStream<Event,
-Error>`) documents the target shape for Milestone 2/3, but per CLAUDE.md §3
-("design seams... can exist in the contracts... but do not build or optimize
-implementation around them yet"), the spec must **not** gain `stream`/`openSession`
-operations, and the generator must **not** emit streaming declarations, until those
-milestones are actually scoped. The spec format should not need reworking when
-that happens — `async: true` already generalizes to a `stream: true` variant
-later — but nothing streaming-shaped gets generated today.
+Error>`) documents the target shape for a future streaming/session milestone, but
+per CLAUDE.md §3 ("design seams... can exist in the contracts... but do not build
+or optimize implementation around them yet"), the spec must **not** gain
+`stream`/`openSession` operations, and the generator must **not** emit streaming
+declarations, until that work is actually scoped. The spec format should not need
+reworking when that happens — `async: true` already generalizes to a `stream: true`
+variant later — but nothing streaming-shaped gets generated today.
 
 ### Option B — reuse JSON Schema via a non-standard `x-methods` extension
 
@@ -245,11 +245,11 @@ The Option A MVP (spec schema + generator + 3 emitters + CI wiring), scoped to
 [`contracts/api/inderun-api.json`](../../contracts/api/inderun-api.json) and
 [`contracts/scripts/generate-api-surface.mjs`](../../contracts/scripts/generate-api-surface.mjs).
 
-Remaining, explicitly deferred (not yet built, per CLAUDE.md's Milestone 1 scope):
+Remaining, explicitly deferred (not yet built, per CLAUDE.md §3 scope):
 
 - `ProviderAdapter` (`describe`/`capabilities`/`run`) as a second, separate
   spec/interface, mirroring how it's already conceptually separate from
   `IndeRunApi` in the architecture docs.
 - Streaming/session operations (`stream`/`openSession`) — the spec format is
   expected to extend to a `stream: true` variant without rework, but no
-  streaming declarations are generated until Milestone 2/3 are actually scoped.
+  streaming declarations are generated until that work is actually scoped.

--- a/docs/architecture/onnx-runtime-provider-family.md
+++ b/docs/architecture/onnx-runtime-provider-family.md
@@ -5,7 +5,7 @@ provider-neutral model-loading contract used for developer-supplied/custom local
 architecture baseline for the platform implementation tickets: #85 (Web), #87 (Android), and #86
 (Apple platforms). Those tickets implement providers; they must not re-decide the boundaries below.
 
-This is a Milestone 2 specification. Field-level shapes live in the schema, not in this prose (see
+Field-level shapes live in the schema, not in this prose (see
 [Model Package Contract](#model-package-contract)). The Web, Apple, and Android members are all
 implemented (see [Web Implementation](#web-implementation), [Apple
 Implementation](#apple-implementation), and [Android Implementation](#android-implementation)).
@@ -58,27 +58,25 @@ DeepSeek-R1-Distill.
 to change"_. Implementers must isolate the GenAI call behind an injectable runtime seam (below) so a
 version change is contained in the adapter.
 
-**Correction — GenAI has no browser build.** ORT GenAI ships Python, .NET, C/C++, and Java packages
-only; there is no JavaScript/browser distribution, and `onnxruntime-web` provides raw inference
-without a generative loop (tokenization, sampling, KV cache). The Web member therefore satisfies the
-_role_ GenAI was mandated for — not the literal package — by defaulting to Transformers.js, which
-runs ONNX models on `onnxruntime-web` and owns the generative loop. Source:
+**GenAI has no browser build.** ORT GenAI ships Python, .NET, C/C++, and Java packages only; there
+is no JavaScript/browser distribution, and `onnxruntime-web` provides raw inference without a
+generative loop (tokenization, sampling, KV cache). The Web member satisfies the _role_ GenAI was
+mandated for — not the literal package — by defaulting to Transformers.js, which runs ONNX models on
+`onnxruntime-web` and owns the generative loop. Source:
 <https://onnxruntime.ai/docs/genai/howto/install.html>.
 
-**Correction — the mobile members target raw ORT Mobile, not the ORT GenAI package.** Both shipped
-mobile members (Apple, Android) default to the platform's raw ONNX Runtime Mobile bindings plus a
-hand-written decode loop and an external tokenizer, rather than
-`onnxruntime-genai`/`onnxruntime-extensions`. This keeps both defaults on the same well-established,
-non-preview API surface used by the Web member's underlying runtime. Both mobile members now
-auto-detect and reuse `past_key_values`/KV-cache export shapes where the graph and `config.json`
-support it (falling back to full-sequence recompute otherwise) and configure an accelerated
-execution provider (CoreML/XNNPACK on Apple, NNAPI/XNNPACK on Android) with a CPU fallback — this is
-no longer a blanket "no KV-cache reuse, CPU-only" limitation, though none of it has been exercised
-against a real model on a real device beyond the plain-path verification noted in each platform
-section (#88). This is exactly what the injectable seam exists for regardless: the seam is the
-contract, and any application (or a future IndeRun default) can supply an
-ORT-GenAI-backed `OnnxGenAiRuntime`/`AndroidOnnxGenAiRuntime` implementation without changing the
-provider.
+**The mobile members target raw ORT Mobile, not the ORT GenAI package.** Both shipped mobile members
+(Apple, Android) default to the platform's raw ONNX Runtime Mobile bindings plus a hand-written
+decode loop and an external tokenizer, rather than `onnxruntime-genai`/`onnxruntime-extensions`. This
+keeps both defaults on the same well-established, non-preview API surface used by the Web member's
+underlying runtime. Both mobile members auto-detect and reuse `past_key_values`/KV-cache export
+shapes where the graph and `config.json` support it (falling back to full-sequence recompute
+otherwise) and configure an accelerated execution provider (CoreML/XNNPACK on Apple, NNAPI/XNNPACK on
+Android) with a CPU fallback, though none of it has been exercised against a real model on a real
+device beyond the plain-path verification noted in each platform section (#88). This is exactly what
+the injectable seam exists for regardless: the seam is the contract, and any application (or a future
+IndeRun default) can supply an ORT-GenAI-backed `OnnxGenAiRuntime`/`AndroidOnnxGenAiRuntime`
+implementation without changing the provider.
 
 **Deterministic fixture fallback.** IndeRun already makes on-device adapters testable without their
 native backend via an injectable runtime interface (`AppleFoundationModelsRuntime`,
@@ -115,7 +113,7 @@ contracts. The schema is intentionally lean and forward-compatible: only `id` an
 required, and unknown fields are permitted. This document does not restate the fields; consult the
 schema.
 
-IndeRun does not own model download/update flows in Milestone 2. Host applications may bundle,
+IndeRun does not own model download/update flows today. Host applications may bundle,
 download, cache, or otherwise supply model files; the model package's `source` describes how.
 
 ## Model Source Support Matrix
@@ -140,7 +138,7 @@ Notes:
   on `bundled`/`app_managed`/`programmatic`/`registry` instead.
 - `remote` (host-managed download) is deferred everywhere: the host application performs the download
   and then supplies files as `bundled`/`app_managed`/`programmatic`. IndeRun does not own the
-  download in Milestone 2.
+  download itself.
 - "Deferred" means the contract permits it but the first implementation need not support it;
   "Unsupported" means the platform cannot honor it.
 
@@ -217,410 +215,87 @@ outcome with no user-visible events after the cancel point, per `architecture.md
 
 ## Web Implementation
 
-The Web member ships in `@independo/inderun-web` under the `./onnx` subpath entry point, kept out of
-the provider-agnostic root index like the OpenAI adapter. Provider id: `local.onnx.genai.web`.
-Descriptor: `type: local`, `transport: in_process`, `supports.run: true` with all forward-looking
-flags false, `cancel: soft`, `privacy.dataLeavesDevice: false`. Option shapes and the error table for
-consumers live in the package README, not here.
+Ships in `@independo/inderun-web` under the `./onnx` subpath entry point. Provider id:
+`local.onnx.genai.web`. Runtime seam: `OnnxTextGenerationRuntime` (`prepare`/`generate`), with a
+default `createTransformersJsRuntime()` (lazy `@huggingface/transformers` import, not bundled by
+IndeRun), a `createFixtureOnnxRuntime()` test/demo seam, and support for an application-supplied
+implementation. Model sources: `registry`, `bundled`, `programmatic`, `app_managed` (see
+[Model Source Support Matrix](#model-source-support-matrix) for the full per-platform picture).
 
-**Runtime seam.** `OnnxTextGenerationRuntime` has two methods: `prepare(modelPackage)` returning the
-`{ available, reason? }` snapshot, and `generate(input, signal)` returning normalized text. Three
-implementations exist:
+Implementation detail (runtime seam internals, quantization defaults, capability gate order, error
+mapping, browser/WASM constraints) lives in code comments in
+[`packages/inderun-web/src/providers/onnx/`](../../packages/inderun-web/src/providers/onnx/) and in
+[`packages/inderun-web/README.md`](../../packages/inderun-web/README.md) — this document does not
+duplicate it, to avoid drifting out of sync with the implementation.
 
-- `createTransformersJsRuntime()` — the default. Lazily imports `@huggingface/transformers`, which the
-  application installs; IndeRun does not bundle it. Initialization failures are reported as
-  _runtime package unavailable_ rather than thrown, so routing degrades to an explainable rejection
-  rather than a crash. The import specifier stays statically resolvable so bundlers can find the
-  package; apps that do not install it supply their own runtime instead.
-- `createFixtureOnnxRuntime()` — the deterministic in-memory fixture mandated above. It is the test
-  seam and lets demos exercise the on-device route offline.
-- Any application-supplied implementation, for example a hand-rolled `onnxruntime-web` pipeline.
-
-Runtime failures are signalled with `OnnxRuntimeError`, whose `kind` (`capability`, `unavailable`,
-`timeout`, `internal`) selects the IndeRun error class per the mapping table above; anything else a
-runtime throws normalizes to `Internal`. Allocation failures during model load (ONNX Runtime reports
-these as `std::bad_alloc` from session creation) are resource exhaustion and map to `Unavailable`,
-not `CapabilityMismatch`.
-
-The default runtime loads quantized weights (`q4f16` on WebGPU, `q4` otherwise) because
-Transformers.js would otherwise select `fp32` and exhaust browser memory. It covers models that load
-through the `text-generation` pipeline, which is the Mode 1 `text_to_text` case this family targets.
-Multimodal exports are split across separate vision/audio/embedding/decoder graphs and need
-`AutoProcessor` plus a model-specific class; that is out of scope for `text_to_text` and, if ever
-needed, belongs in a custom runtime behind the seam rather than in the provider.
-
-**Model sources.** The Web member honors `registry`, `bundled`, `programmatic`, and `app_managed` and
-rejects the other two in `capabilities()`, matching the matrix above: `filesystem` as unsupported
-(browsers cannot read arbitrary local paths) and `remote` as deferred (the host downloads and then
-re-declares the files). The Transformers.js runtime maps `registry` refs to hub model ids, points the
-loader at locally served assets for `bundled`/`app_managed`, and requires an application-supplied
-generator for `programmatic`.
-
-**Capability gate order.** Model package schema validation (reusing `getModelPackageValidationIssues`
-from the contracts package, including its inline-secret and URL-userinfo rules) → Web source-type
-support → `runtime.platforms` includes `web` → declared tasks include `text_to_text` → delegate to
-`runtime.prepare`. Every failure flattens to one `capability_unavailable` route rejection carrying
-the reason string, for example:
-
-- `capability_unavailable`: _model source unavailable: 'filesystem' model sources are unsupported on
-  Web because browsers cannot read arbitrary local paths._
-- `capability_unavailable`: _runtime package unavailable: install the optional dependency
-  @huggingface/transformers (…)._
-- `CapabilityMismatch` at run time when the same gate fails pre-attempt; `Timeout` when the
-  generation budget (`constraints.timeoutMs`, else the provider's `timeoutMs`) elapses; `Unavailable`
-  for runtime initialization failures and resource exhaustion. There is no `AuthError`,
-  `RateLimited`, or `Offline` path.
-
-**Browser constraints.** WASM is the CPU baseline; WebGPU is used when `navigator.gpu` exists.
-Backend choice is an internal detail surfaced only in capability `reason` strings — never a routing
-target. WASM threads require cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and
-`Cross-Origin-Embedder-Policy: require-corp`), and the host application is responsible for serving
-and caching model and ORT WASM assets; IndeRun owns no download or cache layer in Milestone 2.
-
-**Authoring a custom local provider.** Implement `OnnxTextGenerationRuntime` rather than a new
-`ProviderAdapter` when the model is ONNX: the provider already owns descriptor semantics, model
-package validation, source gating, timeouts, and error normalization. Implement `ProviderAdapter`
-directly only for a different runtime family.
+**Authoring a custom local provider:** implement `OnnxTextGenerationRuntime`, per
+[Authoring A Custom Local ONNX Provider](#authoring-a-custom-local-onnx-provider) below.
 
 ## Apple Implementation
 
-The Apple member ships as its own SwiftPM library product, `IndeRunOnnxProviders`
-(`ios/IndeRun/Sources/IndeRunOnnxProviders`), kept out of `IndeRunSwift`/`IndeRunAppleProviders`
-like the Web member is kept out of the provider-agnostic root index. Provider id:
-`local.onnx.genai.apple`. Descriptor: `type: .local`, `transport: .inProcess`, `supports.run:
-true` with all forward-looking flags false, `cancel: .soft`, `privacy.dataLeavesDevice: false`.
+Ships as its own SwiftPM library product, `IndeRunOnnxProviders`
+(`ios/IndeRun/Sources/IndeRunOnnxProviders`). Provider id: `local.onnx.genai.apple`. Runtime seam:
+`OnnxGenAiRuntime` (`prepare`/`generate`), with a default `SystemOnnxGenAiRuntime()` (ONNX Runtime
+SPM bindings + `swift-transformers` tokenizer), a `createFixtureOnnxRuntime(options:)` test/demo
+seam, and support for an application-supplied implementation. Model sources: `bundled`,
+`programmatic`, `app_managed`, `filesystem` (see
+[Model Source Support Matrix](#model-source-support-matrix)).
 
-**Platform minimums.** Landing this member raised the whole SDK's minimum platforms from iOS 15 /
-macOS 12 to **iOS 16 / macOS 14**, because its dependencies require it: the official ONNX Runtime
-SPM bindings (`microsoft/onnxruntime-swift-package-manager`, macOS 14 minimum) and
-`swift-transformers`'s `Tokenizers` module (iOS 16 minimum). SwiftPM has no per-target platform
-override in a single manifest, so this is a package-wide, breaking bump — every IndeRun Apple
-consumer, not only ONNX users, now needs iOS 16 / macOS 14.
+Landing this member raised the whole SDK's minimum platforms to **iOS 16 / macOS 14** — a
+package-wide, breaking bump for every IndeRun Apple consumer, not only ONNX users — because its
+dependencies require it; see `Package.swift`.
 
-**Runtime seam.** `OnnxGenAiRuntime` has two methods: `prepare(_:)` returning the `{available,
-reason?}` snapshot, and `generate(_:)` returning normalized text — the same shape as the Web
-member's `OnnxTextGenerationRuntime`, adapted to Swift Concurrency (cancellation is ambient via
-`Task` cancellation rather than an explicit `AbortSignal` parameter). Two implementations exist:
+Implementation detail (decode-strategy auto-detection between the plain and KV-cache IO shapes,
+execution-provider fallback and the KV-cache/CoreML incompatibility, buffer reuse, sampling,
+capability gate order, cancellation semantics) lives in code comments in
+[`ios/IndeRun/Sources/IndeRunOnnxProviders/`](../../ios/IndeRun/Sources/IndeRunOnnxProviders/) —
+this document does not duplicate it, to avoid drifting out of sync with the implementation. Real
+device verification beyond the plain decode path is tracked in #88.
 
-- `SystemOnnxGenAiRuntime()` — the default. Tokenizes with `swift-transformers`'s
-  `AutoTokenizer.from(modelFolder:)`, applying the tokenizer's chat template
-  (`Tokenizer.applyChatTemplate`) when `tokenizer_config.json` declares one and falling back to a
-  plain `"role: content"` join otherwise; runs inference through the official ONNX Runtime SPM
-  bindings (`OnnxRuntimeBindings` / `ORTSession`). **IO contract**: both supported decode paths
-  below require `input_ids`/`attention_mask` inputs (`int64`) and a `logits` output (`float32`,
-  `[1, sequenceLength, vocabSize]`). Which path a given model uses is auto-detected from the
-  graph's declared input names at load time — no `ModelPackage` field or app-facing configuration
-  selects it:
-  - **Plain** (no `past_key_values.*` inputs): shape `[1, sequenceLength]`, the full sequence
-    recomputed every decode step. Always supported; the fallback whenever KV-cache detection can't
-    establish every assumption below.
-  - **KV-cache** (`past_key_values.{layer}.key`/`.value` inputs present, the legacy (non-merged)
-    Hugging Face Optimum `decoder_with_past_model` export convention): exactly one token is fed as
-    `input_ids` per model call — this graph shape traces `input_ids`'s sequence-length axis fixed
-    at 1, not dynamic, so (unlike a merged/optional-past graph) it cannot accept the whole prompt
-    in a single call. The prompt is therefore replayed through the same session one token at a
-    time (discarding logits) to build up `past_key_values` before the first real generated token,
-    then generation proceeds one token per call the same way, with `attention_mask` covering the
-    full running sequence and each call's `present.{layer}.key`/`.value` outputs threaded back in
-    as the next call's `past_key_values.*` inputs directly (no copy). Detection additionally
-    requires `num_hidden_layers` (or GPT-2-style `n_layer`), `num_attention_heads`/`n_head` (or
-    `num_key_value_heads` for GQA models), and `hidden_size`/`n_embd` (or an explicit `head_dim`)
-    to be readable from `config.json` in the model directory, and every expected
-    `past_key_values.{layer}.{key,value}` input /
-    `present.{layer}.{key,value}` output to be present by that naming convention; an optional
-    `position_ids` input is fed the running absolute position when the graph declares it. Graphs
-    that instead declare a `use_cache_branch` boolean input (merged Optimum exports, which accept
-    the whole prompt on their first call) fall back to the plain path instead — the ONNX Runtime
-    Objective-C bindings this runtime depends on (as of `onnxruntime-swift-package-manager`
-    1.24.2) expose no `bool` tensor element type to feed it, and this runtime does not implement
-    the merged graph's alternate calling convention. This path's one-token-per-call shape was
-    corrected against a real device failure (`Got invalid dimensions for input: input_ids ...
-    Expected: 1`) surfaced by a real exported model (LaMini-GPT, added to the iOS demo app);
-    detection remains deliberately conservative — any unresolvable assumption falls back to the
-    plain path rather than guessing. See #88 for remaining broader real-device verification (load
-    time, memory, cancellation, other model families).
-
-  **Graph file convention**: `ModelPackage.files.required` has no positional semantics of its own
-  in the schema, so this runtime defines one — the _first_ entry is the ONNX graph file; any
-  remaining entries (for example external weight shards) must be present alongside it but are not
-  referenced directly. `ModelPackage.integrity.checksums` (`sha256:<hex>`) are verified for every
-  file this runtime resolves, before load. The session cache key covers `id`, `version`, `source`,
-  and `integrity.checksums` together, not `id` alone, so swapping a model's bytes without bumping
-  `id` does not silently keep serving a stale session.
-
-  **Execution.** A single `ORTEnv` is created once and shared process-wide across every session,
-  per ORT's own guidance that one environment should exist per process rather than per session.
-  Session creation and every `run()` call execute on a dedicated serial queue rather than inline on
-  the Swift Concurrency cooperative thread pool, since `ORTSession.init`/`run()` are blocking
-  synchronous calls. The CoreML execution provider is configured by default on the plain decode
-  path (`ORTCoreMLExecutionProviderOptions` with its own defaults), falling back to XNNPACK and
-  then ORT's default CPU EP if CoreML EP configuration fails on the host (availability and
-  compilation behavior vary by device/OS); `setIntraOpNumThreads` is set explicitly, bounded by
-  the device's active processor count, rather than left at ORT's implicit default. CoreML compiles
-  the graph into an on-device `.mlmodelc` cache on first load — managed entirely by ORT/CoreML, not
-  by IndeRun — keyed by the model and execution-provider options, and invalidated by a changed
-  model file or EP option set. **The KV-cache path never uses CoreML**, regardless of host
-  availability: its first decode call feeds a genuinely zero-length `past_key_values` tensor (see
-  above), and ORT's CoreML EP rejects a dynamic-shaped input with zero elements at run time
-  (`Input (past_key_values.0.key) has a dynamic shape (...) but the runtime shape (...) has zero
-  elements. This is not supported by the CoreML EP.` — a real device failure surfaced by
-  LaMini-GPT, not a hypothetical one); since ORT's execution provider list is fixed at
-  session-creation time, not selectable per call, that graph's session is created directly on
-  XNNPACK/CPU. The plain decode path preallocates its `input_ids`/`attention_mask`
-  buffers once per generation (sized to the max possible sequence length) and writes into a
-  subrange each step rather than allocating fresh buffers per token; the KV-cache path's per-call
-  buffers are already fixed-size (exactly one token each), and its `past_key_values` reuse (above)
-  is itself the buffer-reuse win for that path — though note the prompt-replay calls mean this
-  path issues one ORT call per prompt token plus one per generated token, not one call per
-  generated token as the plain path does.
-
-  **Decoding** defaults to greedy (argmax). Setting `generation.temperature` switches to sampling:
-  logits are scaled by `1 / temperature`, optionally narrowed to the smallest token set whose
-  cumulative probability reaches `generation.topP` (nucleus sampling), then sampled — seeded
-  (reproducibly) when `generation.seed` is set, otherwise drawn from
-  `SystemRandomNumberGenerator`. `generation.stop` sequences are honored on both decode paths.
-  Apps that need an accelerated execution provider this runtime doesn't configure, a different
-  sampling strategy, or a KV-cache export shape this runtime doesn't auto-detect (for example
-  `use_cache_branch`-gated merged graphs) supply their own `OnnxGenAiRuntime`; real-device
-  verification (load time, token latency, peak memory, cancellation behavior, repeated-run
-  stability against an actual model, for both decode paths) is tracked in #88 — this default has
-  not yet been run against a real model on-device. `programmatic` model sources are also out of
-  scope for this default runtime (no files to resolve, matching the Web member's own
-  `programmatic` carve-out); it reports _runtime package unavailable_ rather than throwing.
-- `createFixtureOnnxRuntime(options:)` — the deterministic in-memory fixture mandated above,
-  public/importable like the Web member's `createFixtureOnnxRuntime` (this diverges deliberately
-  from the private-to-tests fixture convention used by `AppleFoundationModelsProvider`, per the
-  fixture's explicit mandate to support offline demos as well as tests).
-- Any application-supplied implementation of `OnnxGenAiRuntime`.
-
-**Model sources.** The Apple member honors `bundled`, `programmatic`, `app_managed`, and
-`filesystem`, and rejects `registry` and `remote` in `capabilities()`, matching the support
-matrix above. `SystemOnnxGenAiRuntime` resolves `bundled` under `Bundle.main.resourceURL`,
-`filesystem` and `app_managed` as a directory path from `source.ref` (absolute for `filesystem`,
-relative to the app's Application Support directory for `app_managed`).
-
-**Capability gate order.** Model package structural validation (a hand-written
-`getModelPackageValidationIssues` in `IndeRunOnnxProviders` — no generated JSON Schema validator
-exists in Swift, so this is a scoped subset covering `id`/`format` presence, inline-secret keys,
-and `source.ref` URL-userinfo, not a full AJV-equivalent port) → Apple source-type support →
-`runtime.platforms` includes `apple` → declared tasks include `text_to_text` → delegate to
-`runtime.prepare`. Every failure flattens to one `capability_unavailable` route rejection, for
-example:
-
-- `capability_unavailable`: _model source unavailable: 'registry' model sources are deferred on
-  Apple platforms; supply model files as bundled, programmatic, app_managed, filesystem._
-- `capability_unavailable`: _model files missing: 'model.onnx' not found at \<resolved path\>._
-- `CapabilityMismatch` at run time when the same gate fails pre-attempt; `Timeout` when the
-  generation budget (`constraints.timeoutMs`, else the provider's configured timeout) elapses;
-  `Unavailable` for ONNX Runtime session initialization failures. There is no `AuthError`,
-  `RateLimited`, or `Offline` path. Real `Task` cancellation (the caller cancelling its own task,
-  as opposed to the provider's own deadline elapsing) propagates as a raw `CancellationError`
-  rather than an `IndeRunException`, matching the established Swift-side convention
-  (`OpenAIProvider`, `IndeRun.swift`) rather than the Web member's `AbortError → Timeout` mapping —
-  the two platforms differ here because Swift Concurrency has first-class cancellation and the
-  rest of this SDK already relies on it. `ORTSession.run()` itself is a blocking synchronous call
-  that cannot be interrupted mid-call; cancellation is observed only between decode steps
-  (`cancel: .soft`), so a cancelled or timed-out request still waits out its current in-flight
-  step.
-
-**Packaging and binary size.** ORT Mobile's native binary is statically linked via the SPM
-`onnxruntime` product and adds meaningfully to app binary size; the model files themselves must
-also fit on-device disk and load into device memory (see
-[Platform Constraints](#platform-constraints-reference)). Neither IndeRun nor this provider owns
-model download/update flows in Milestone 2 — apps that fetch models remotely still supply them as
-`bundled`/`app_managed`/`programmatic` once resolved, per the model source matrix.
-
-**Authoring a custom local provider.** Implement `OnnxGenAiRuntime` rather than a new
-`ProviderAdapter` when the model is ONNX: `OnnxRuntimeAppleProvider` already owns descriptor
-semantics, model package validation, source gating, timeouts, and error normalization. Implement
-`ProviderAdapter` directly only for a different runtime family, mirroring the Web guidance above.
+**Authoring a custom local provider:** implement `OnnxGenAiRuntime`, per
+[Authoring A Custom Local ONNX Provider](#authoring-a-custom-local-onnx-provider) below.
 
 ## Android Implementation
 
-The Android member ships as its own Gradle library module, `inderun-onnx-providers`
-(`android/inderun-onnx-providers`), following the same one-module-per-provider-family convention as
-`inderun-mlkit-providers` and `inderun-openai-providers`. Provider id: `local.onnx.genai.android`.
-Descriptor: `type: local`, `transport: in_process`, `supports.run: true` with all forward-looking
-flags false, `cancel: soft`, `privacy.dataLeavesDevice: false`.
+Ships as its own Gradle library module, `inderun-onnx-providers` (`android/inderun-onnx-providers`).
+Provider id: `local.onnx.genai.android`. Runtime seam: `AndroidOnnxGenAiRuntime`
+(`prepare`/`generate`), with a default `SystemAndroidOnnxGenAiRuntime(context)` (ONNX Runtime Mobile
+Java bindings + a Hugging Face tokenizer via `ai.djl`), a `createFixtureOnnxRuntime(options)`
+test/demo seam, and support for an application-supplied implementation. Model sources: `bundled`,
+`programmatic`, `app_managed`, `filesystem` (see
+[Model Source Support Matrix](#model-source-support-matrix)).
 
-**Runtime seam.** `AndroidOnnxGenAiRuntime` has two suspend methods: `prepare(modelPackage)`
-returning the `{available, reason?}` snapshot, and `generate(input)` returning normalized text — the
-same shape as the Web and Apple members' runtime seams, adapted to Kotlin Coroutines (cancellation
-is ambient via coroutine `Job` cancellation, matching Apple's `Task` cancellation model rather than
-the Web member's explicit `AbortSignal` parameter). Two implementations exist:
+Implementation detail (decode-strategy auto-detection, execution-provider fallback and the
+KV-cache/NNAPI incompatibility, buffer reuse, sampling, the Android-specific
+`libc++_shared.so`/`tokenizer-native` packaging fix, capability gate order, cancellation semantics)
+lives in code comments in
+[`android/inderun-onnx-providers/`](../../android/inderun-onnx-providers/) — this document does not
+duplicate it, to avoid drifting out of sync with the implementation. One notable platform gap:
+unlike Apple and Web, this default runtime does not apply chat templates (the DJL tokenizer binding
+exposes no equivalent API), falling back unconditionally to a plain `"role: content"` join. Real
+device verification beyond the plain-path DistilGPT-2 check is tracked in #88.
 
-- `SystemAndroidOnnxGenAiRuntime(context)` — the default. Runs inference through ONNX Runtime
-  Mobile's Java bindings (`com.microsoft.onnxruntime:onnxruntime-android`) and tokenizes with a
-  Hugging Face tokenizer (`ai.djl.huggingface:tokenizers` plus its Android native binding,
-  `ai.djl.android:tokenizer-native`). Implemented across several files by concern, mirroring the
-  Apple member's own split (`SystemOnnxGenAiRuntime.swift` + `OnnxSessionLoading*.swift` +
-  `OnnxSampling.swift` + `OnnxTensorExecution.swift` + `SystemOnnxGenAiRuntime+Decoders.swift`):
-  `SystemAndroidOnnxGenAiRuntime.kt` (orchestration), `OnnxSessionLoading.kt` (session/tokenizer/EP
-  loading, asset extraction, checksums), `OnnxSessionLoadingKvCacheDetection.kt` (decode-strategy
-  detection), `OnnxDecoders.kt` (the two decode-step strategies below), `OnnxSampling.kt`
-  (temperature/top-p/seed sampling), and `OnnxTensorExecution.kt` (the dedicated dispatcher and
-  `OrtException`-wrapping run helper).
+**Authoring a custom local provider:** implement `AndroidOnnxGenAiRuntime`, per
+[Authoring A Custom Local ONNX Provider](#authoring-a-custom-local-onnx-provider) below.
 
-  **IO contract**: this runtime auto-detects, from the loaded graph's declared input names, which
-  of two decoder-only export shapes a model uses — no `ModelPackage` field or app-facing
-  configuration selects it, identical in spirit to the Apple member's detection:
-  - **Plain** (no `past_key_values.*` inputs): shape `[1, sequenceLength]`, the full sequence
-    recomputed every decode step. Always supported; the fallback whenever KV-cache detection can't
-    establish every assumption below.
-  - **KV-cache** (`past_key_values.{layer}.key`/`.value` inputs present, the legacy (non-merged)
-    Hugging Face Optimum `decoder_with_past_model` export convention): exactly one token is fed as
-    `input_ids` per model call — this graph shape traces `input_ids`'s sequence-length axis fixed
-    at 1, so the prompt is replayed through the same session one token at a time (discarding
-    logits) to build up `past_key_values` before the first real generated token, then generation
-    proceeds one token per call the same way, with each call's `present.{layer}.key`/`.value`
-    outputs threaded back in as the next call's `past_key_values.*` inputs directly (no copy).
-    Detection additionally requires `num_hidden_layers` (or GPT-2-style `n_layer`),
-    `num_attention_heads`/`n_head` (or `num_key_value_heads` for GQA models), and
-    `hidden_size`/`n_embd` (or an explicit `head_dim`) to be readable from `config.json`, and every
-    expected `past_key_values.{layer}.{key,value}` input / `present.{layer}.{key,value}` output to
-    be present by that naming convention; an optional `position_ids` input is fed the running
-    absolute position when the graph declares it. Graphs that instead declare a `use_cache_branch`
-    boolean input (merged Optimum exports) fall back to the plain path — this runtime does not
-    implement the merged graph's alternate calling convention. Detection is deliberately
-    conservative — any unresolvable assumption falls back to the plain path rather than guessing —
-    and, like the rest of this default runtime, has not been exercised against a real KV-cache
-    export on an Android device; that remains part of #88, mirroring the Apple member's own
-    real-device carve-out (the Apple member's equivalent path *was* corrected against a real device
-    failure on LaMini-GPT — the Android path is unverified, not merely undocumented).
+## Authoring A Custom Local ONNX Provider
 
-  **Graph file convention**: same as Apple — `ModelPackage.files.required`'s _first_ entry is the
-  ONNX graph file; remaining entries (for example external weight shards) must be present alongside
-  it. Every file named in `ModelPackage.integrity.checksums` is verified before load, not only the
-  required-file list; an algorithm prefix other than `sha256:` is a capability failure rather than a
-  silently skipped check. The session cache key covers `id`, `format`, `version`, `source`, and
-  `integrity.checksums` together, not `id` alone.
-
-  **Execution.** `OrtEnvironment.getEnvironment()` already returns a process-wide singleton per its
-  own Java API contract, so — unlike the Apple member's `ORTEnv`, which needed an explicit
-  shared-instance wrapper — no separate wrapper is needed here; every session reuses the same
-  environment instance as-is. Session creation and every `run()` call execute on a dedicated
-  single-thread `CoroutineDispatcher` rather than `Dispatchers.IO`/`Dispatchers.Default`, since
-  `OrtSession.run()` and session construction are blocking synchronous calls. The NNAPI execution
-  provider is configured by default on the plain decode path (`SessionOptions.addNnapi()`), falling
-  back to XNNPACK (`addXnnpack`) and then ORT's default CPU EP if NNAPI configuration fails on the
-  host; `setIntraOpNumThreads` is set explicitly, bounded by the device's available processor
-  count, rather than left at ORT's implicit default. **The KV-cache path never uses NNAPI**,
-  regardless of host availability: its first decode call feeds a genuinely zero-length
-  `past_key_values` tensor, and the Apple member's CoreML EP is documented to reject an analogous
-  zero-length dynamic-shaped input at run time on a real device — this runtime applies the same
-  conservative rule to NNAPI on the same reasoning, but whether NNAPI actually rejects it the same
-  way is an unverified assumption carried over from the Apple finding, not a confirmed
-  Android-device result (#88). Since ORT's execution provider list is fixed at session-creation
-  time, that graph's session is created directly on XNNPACK/CPU. The plain decode path preallocates
-  its `input_ids`/`attention_mask` buffers once per generation, as direct `LongBuffer`s sized to
-  `promptLength + maxOutputTokens`, and writes into a growing subrange each step rather than
-  allocating a fresh buffer per token; the KV-cache path's `past_key_values` reuse (above) is itself
-  the buffer-reuse win for that path.
-
-  **Decoding** defaults to greedy (argmax). Setting `generation.temperature` switches to sampling:
-  logits are scaled by `1 / temperature`, optionally narrowed to the smallest token set whose
-  cumulative probability reaches `generation.topP` (nucleus sampling), then sampled — seeded
-  (reproducibly) via `kotlin.random.Random(seed)` when `generation.seed` is set, natively seedable
-  unlike the Apple member's `SystemRandomNumberGenerator` (which needed a custom `SplitMix64`).
-  `generation.stop` sequences are honored on both decode paths. **Stop conditions**: generation
-  stops on the tokenizer's end-of-sequence token — resolved from the model config JSON's
-  `eos_token_id` field, since the DJL tokenizer binding does not expose special token ids the way
-  `swift-transformers` does on Apple — on a `generation.stop` suffix match, or once
-  `maxOutputTokens` is reached, whichever comes first; cancellation is checked before every decode
-  step.
-
-  Unlike the Apple and Web members, this default runtime does **not** attempt chat-template
-  application: `ai.djl.huggingface:tokenizers` (`0.33.0`) exposes no `applyChatTemplate`-equivalent
-  API or special-token accessor on its public `HuggingFaceTokenizer` surface — this is a verified,
-  permanent gap for this runtime, not an oversight pending evaluation, and it falls back
-  unconditionally to a plain `"role: content"` join. Apps that need chat templates, an execution
-  provider/sampling strategy this runtime doesn't configure, or a KV-cache export shape this runtime
-  doesn't auto-detect (for example `use_cache_branch`-gated merged graphs) supply their own
-  `AndroidOnnxGenAiRuntime`; real-device verification (load time, token latency, peak memory,
-  cancellation behavior, repeated-run stability against an actual model, for both decode paths, and
-  whether NNAPI actually degrades on the KV-cache path's zero-length tensor the way CoreML does) is
-  tracked in #88 — this default has not yet been run against a real model on-device beyond the
-  plain-path DistilGPT-2 verification below. `programmatic` model sources are out of scope for this
-  default runtime (no files to resolve, matching the Web/Apple members' own `programmatic`
-  carve-out); it reports _runtime package unavailable_ rather than throwing.
-
-  **Native dependency**: `ai.djl.android:tokenizer-native`'s
-  prebuilt `libdjl_tokenizer.so` dynamically links `libc++_shared.so`, but the artifact does not
-  bundle it — an app that depends on `inderun-onnx-providers` and doesn't separately provide
-  `libc++_shared.so` for every targeted ABI fails the first tokenizer load with
-  `UnsatisfiedLinkError: dlopen failed: library "libc++_shared.so" not found`, surfaced by this
-  provider as a `capability_unavailable` "tokenizer/config missing" reason (the underlying
-  `UnsatisfiedLinkError` is attached as `originalError` but not included in the reason string).
-  `inderun-onnx-providers` now declares a no-op CMake native target
-  (`src/main/cpp/CMakeLists.txt`, `-DANDROID_STL=c++_shared`) purely so the NDK's own CMake
-  toolchain copies the matching `libc++_shared.so` into the build output per ABI and AGP packages
-  it — no binary committed to source control, sourced from the module's declared `ndkVersion`
-  instead. This was found and fixed via real-device
-  verification on an Android emulator (arm64-v8a, API 34): the default runtime downloads, loads,
-  and generates text from a real DistilGPT-2 ONNX export end-to-end on the plain (no-KV-cache,
-  no-sampling) decode path (load time, token latency, and repeated-run stability were not
-  separately profiled — that remains a follow-up, matching the Apple member's own #88 carve-out).
-  The EP configuration, KV-cache decode path, and sampling added since have not themselves been
-  re-verified against that or any other real device.
-- `createFixtureOnnxRuntime(options)` — the deterministic in-memory fixture mandated above,
-  public/importable like the Web and Apple members' fixtures.
-- Any application-supplied implementation of `AndroidOnnxGenAiRuntime`.
-
-**Model sources.** The Android member honors `bundled`, `programmatic`, `app_managed`, and
-`filesystem`, and rejects `registry` and `remote` in `capabilities()`, matching the support matrix
-above. `SystemAndroidOnnxGenAiRuntime` resolves `bundled` by copying the referenced Android asset
-directory (`context.assets`) into app-private storage, into a directory keyed by the session cache
-key (not by `id` alone) so a changed `version`/`ref`/checksum extracts into a fresh directory
-instead of reusing stale bytes; extraction is atomic (copied into a temp directory, marked complete,
-then moved into place) so an interrupted copy cannot poison a later load. `filesystem` and
-`app_managed` resolve to a directory path from `source.ref` (absolute for `filesystem`, relative to
-`context.filesDir` for `app_managed`).
-
-**Capability gate order.** Identical to the Apple member: model package structural validation (a
-hand-written `getModelPackageValidationIssues` in `inderun-onnx-providers` — no generated JSON
-Schema validator exists in Kotlin, so this is a scoped subset covering `id` presence, inline-secret
-keys, and `source.ref` URL-userinfo, not a full AJV-equivalent port) → Android source-type support →
-`runtime.platforms` includes `android` → declared tasks include `text_to_text` → delegate to
-`runtime.prepare`. Every failure flattens to one `capability_unavailable` route rejection, for
-example:
-
-- `capability_unavailable`: _model source unavailable: 'registry' model sources are deferred on
-  Android; supply model files as bundled, programmatic, app_managed, filesystem._
-- `capability_unavailable`: _model files missing: 'model.onnx' not found at \<resolved path\>._
-- `CapabilityMismatch` at run time when the same gate fails pre-attempt; `Timeout` when the
-  generation budget (`constraints.timeoutMs`, else the provider's configured timeout) elapses via a
-  `withTimeout` race around `runtime.generate`; `Unavailable` for ONNX Runtime session
-  initialization failures. There is no `AuthError`, `RateLimited`, or `Offline` path. Real coroutine
-  cancellation (the caller cancelling its own job, as opposed to the provider's own deadline
-  elapsing) propagates as a raw `CancellationException` rather than an `IndeRunException`, matching
-  the Apple member's `CancellationError` convention rather than the Web member's `AbortError →
-Timeout` mapping. `OrtSession.run()` itself is a blocking synchronous call that cannot be
-  interrupted mid-call; cancellation is observed only between decode steps (`cancel: soft`).
-
-**Packaging and binary size.** ORT Mobile's Android AAR bundles native `.so` libraries per ABI and
-adds meaningfully to app binary size; the model files themselves must also fit on-device disk and
-load into device memory (see [Platform Constraints](#platform-constraints-reference)). Neither
-IndeRun nor this provider owns model download/update flows in Milestone 2 — apps that fetch models
-remotely still supply them as `bundled`/`app_managed`/`programmatic` once resolved, per the model
-source matrix.
-
-**Authoring a custom local provider.** Implement `AndroidOnnxGenAiRuntime` rather than a new
-`ProviderAdapter` when the model is ONNX: `AndroidOnnxRuntimeProvider` already owns descriptor
+For a new ONNX-backed model, implement the runtime seam for the target platform
+(`OnnxTextGenerationRuntime` on Web, `OnnxGenAiRuntime` on Apple, `AndroidOnnxGenAiRuntime` on
+Android) rather than a new `ProviderAdapter`: the existing platform provider already owns descriptor
 semantics, model package validation, source gating, timeouts, and error normalization. Implement
-`ProviderAdapter` directly only for a different runtime family, mirroring the Web and Apple guidance
-above.
+`ProviderAdapter` directly only for a different runtime family.
 
-## Documentation Requirements For Platform Tickets (#85–#87)
+## Documentation Requirements For Future Platform Work
 
-Each platform implementation must update, in the same task:
+A change to this provider family (new platform member, new model source type, new capability
+condition) must update, in the same task:
 
 - the provider matrix / family overview (`providers.md` and this document as needed)
 - the supported model source types for that platform (this document's matrix)
 - model package requirements it relies on (reference the `ModelPackage` schema; do not duplicate)
-- platform-specific constraints (browser/runtime for Web; packaging, binary size, accelerators for
-  mobile — see platform notes below)
-- route rejection / error examples for that platform
-- provider-authoring notes for custom local model providers
+- the relevant platform's code comments (implementation detail belongs there, not here — see
+  CONTEXT.md §8 "Where technical detail belongs")
 
 ## Platform Constraints (Reference)
 

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -33,58 +33,51 @@ intentional:
 The class-to-cause mapping lives in code (provider adapters and the error
 factories), not in prose.
 
-## Current Provider Families
+## Provider Matrix
 
-- iOS on-device: Apple Foundation Models provider
-- Android on-device: ML Kit GenAI provider
-- Web and native cloud: OpenAI-compatible provider
-  - `capabilities()` probes endpoint reachability with a cheap, unauthenticated `GET` against the
-    configured endpoint after the static host-service checks pass — the OpenAI API (and
-    OpenAI-compatible servers generally) has no dedicated health endpoint, so this is the
-    lightest-weight signal available. A response with status `>= 500`, or a network-level probe
-    failure (timeout, connection error), reports `available: false`; any other HTTP response
-    (including 4xx, which just signals a method/auth mismatch on the probe request, not that the
-    service is down) reports `available: true`. Because a provider that fails this probe is
-    excluded as a routing candidate before `run()` is attempted, an unreachable endpoint now fails
-    fast with an `Unavailable` error instead of being attempted and timing out mid-request. The
-    result is cached briefly (`healthCheckCacheMs`, default 5000ms) since this same
-    `capabilities()` call is shared by both the router (on every real `run()`) and
-    `checkCapabilities()` (UI introspection) — see `docs/architecture/architecture.md`.
-- Custom/developer-supplied local models: ONNX Runtime provider family (Milestone 2, specified in
-  [onnx-runtime-provider-family.md](onnx-runtime-provider-family.md))
-  - Web on-device: `local.onnx.genai.web`, shipped in `@independo/inderun-web/onnx`
-  - Apple on-device: `local.onnx.genai.apple`, shipped in the `IndeRunOnnxProviders` SwiftPM
-    library product; raised the SDK's Apple platform minimums to iOS 16 / macOS 14 (see
-    [Apple Implementation](onnx-runtime-provider-family.md#apple-implementation)). Demonstrated
-    alongside Apple Foundation Models and the OpenAI-compatible cloud provider, routed by
-    `checkCapabilities()` and a `Privacy`-preference selector, in the iOS sample app
-    (`ios/SampleApps/IndeRunDemo`). Depends transitively on `swift-huggingface` (via
-    `swift-transformers`' `Tokenizers`) for `AutoTokenizer.from(modelFolder:)`, used only to
-    load tokenizer config from an already-resolved local directory with hardcoded literal
-    filenames (`config.json`, `tokenizer.json`, ...) — no Hub network/download/cache APIs
-    (`HubApi.snapshot(from:)`, `.from(pretrained:)`, `HubCache`/`HubClient`) are called today.
-    Those Hub-network/cache-path APIs have open CodeQL `swift/path-injection` findings
-    upstream (`HubCache.cachedFilePath` builds cache paths from `revision`/`filename` without
-    the same validation `storeFile`/`storeData` apply; tracked in
-    huggingface/swift-huggingface#62). Before any
-    future code calls those APIs with a repo ID or filename that isn't a hardcoded literal,
-    check whether that issue is resolved, and if not, validate repo-id/filename inputs at the
-    call site.
-  - Android on-device: `local.onnx.genai.android`, shipped in the `inderun-onnx-providers` Gradle
-    module (see [Android Implementation](onnx-runtime-provider-family.md#android-implementation)).
-    Demonstrated alongside Android ML Kit GenAI and the OpenAI-compatible cloud provider, routed
-    by `checkCapabilities()` and a `PrivacyPreference` selector, in the Android sample app
-    (`android/inderun-demo-app`). Requires `libc++_shared.so` per ABI, which the module gets AGP
-    to package via a no-op CMake native target (see the module's `src/main/cpp/`) —
-    `ai.djl.android:tokenizer-native`'s prebuilt `libdjl_tokenizer.so` dynamically links it but
-    does not ship it itself, so a consumer app that omits it fails with `UnsatisfiedLinkError:
-    dlopen failed: library "libc++_shared.so" not found` the first time the tokenizer loads.
-- Browser-managed on-device models: Web system-model provider family (Milestone 2, specified in
-  [web-system-model-provider-family.md](web-system-model-provider-family.md)) — the browser owns
-  model availability/download/execution, unlike the developer-supplied ONNX family
-  - Web on-device: `local.system-model.web` (Chrome Prompt API, `LanguageModel`), shipped in
-    `@independo/inderun-web/system-model`
-  - Desktop Chrome 138+ only; degrades honestly (`capability_unavailable`) elsewhere
+| Provider family | Web | iOS/macOS | Android | Classification | Task support | Interaction modes | Capability check | Credentials / model loading | Key limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| OpenAI-compatible | Supported | Supported | Supported | Cloud | `text_to_text` | `run` (Mode 1) | Cheap unauthenticated `GET` probe against the configured endpoint, cached (`healthCheckCacheMs`, default 5000ms) | `authContextRef`; no raw secrets in payloads | No dedicated health endpoint; 4xx on the probe still counts as `available: true` |
+| Apple Foundation Models | Not applicable | Supported | Not applicable | Platform-local | `text_to_text` | `run` (Mode 1) | Static host-service check (OS/device support) | None — OS-managed model | iOS/macOS only; model availability gated by OS |
+| Android ML Kit GenAI (Gemini Nano) | Not applicable | Not applicable | Supported | Platform-local | `text_to_text` | `run` (Mode 1) | Static host-service check (device/OS support) | None — OS-managed model | Android only; device-tier gated |
+| ONNX Runtime (`local.onnx.genai.*`) | Shipped (`@independo/inderun-web/onnx`) | Shipped (`IndeRunOnnxProviders` SwiftPM, iOS 16+/macOS 14+) | Shipped (`inderun-onnx-providers` Gradle module) | Custom/developer-supplied local | `text_to_text` | `run` (Mode 1) | Static + dynamic host capability check per platform | Developer supplies model + tokenizer files; no Hub network/download APIs called today | Android requires `libc++_shared.so` packaged by the consumer app; see [onnx-runtime-provider-family.md](onnx-runtime-provider-family.md) |
+| Web system-model (`local.system-model.web`) | Shipped (`@independo/inderun-web/system-model`, Chrome Prompt API `LanguageModel`) | Not applicable | Not applicable | Browser-local | `text_to_text` | `run` (Mode 1) | Runtime feature-detection against the browser API | None — browser-managed model/download | Desktop Chrome 138+ only; degrades honestly (`capability_unavailable`) elsewhere; see [web-system-model-provider-family.md](web-system-model-provider-family.md) |
+
+Streaming (`stream`) and realtime sessions (`openSession`) are not implemented by any provider today — see `CONTEXT.md` §3 for current Mode 1/2/3 status. Do not read this table as implying streaming support.
+
+### Demos & Tests per Family
+
+- **OpenAI-compatible** — `packages/inderun-web/src/providers/openai/provider.test.ts` (reachability, auth, rate-limit/timeout/unavailable/internal error mapping); iOS/Android per-provider suites in `ios/IndeRun/Tests/IndeRunTests` and `android/*/src/test`; live in every sample/demo app below.
+- **Apple Foundation Models** — `ios/IndeRun/Tests/IndeRunTests` (descriptor, unavailable capability, run success, error mapping); demoed in `ios/SampleApps/IndeRunDemo`.
+- **Android ML Kit GenAI** — `AndroidMlKitGenAiProviderTest.kt`; demoed in `android/inderun-demo-app`.
+- **ONNX Runtime** — `packages/inderun-web/src/providers/onnx/{provider,transformers-runtime}.test.ts` (capability rejection, `local_required` no-fallback, runtime-error → error-class mapping); Apple/Android equivalents in the same test trees as above; demoed in `ios/SampleApps/IndeRunDemo` and `android/inderun-demo-app`.
+- **Web system-model** — `packages/inderun-web/src/providers/system-model/{provider,chrome-runtime}.test.ts` (availability states, error mapping, `local_required` behavior). Not yet wired into `packages/inderun-web-demo` (tracked as a follow-up) — the web demo currently covers cloud + ONNX only.
+- **Route selection/rejection + normalized errors** — `rust/inderun-route-core/src/tests.rs` is the canonical suite for rejection reasons (`rejected_providers[].reasons[].code`) and deterministic fallback ordering; `packages/inderun-web/src/core/engine.test.ts` covers the same at the TS engine layer (`CapabilityMismatch`/`Offline`/`Unavailable`, telemetry). The iOS and Android demo app READMEs each document an "Expected Failure Modes" section with concrete triggering scenarios per `errorClass`.
+
+To run this coverage: `pnpm test:js` (Web/TS provider + engine tests), `cargo test -p inderun_route_core` (routing/rejection), `swift test` (iOS), `cd android && ./gradlew test` (Android). See each package's README for demo-app run instructions.
+
+## Provider Notes
+
+Implementation nuance not captured by the matrix above:
+
+- **OpenAI-compatible reachability probe.** The `>= 5xx`-or-network-failure vs. everything-else
+  (including 4xx) split exists because OpenAI-compatible servers have no dedicated health
+  endpoint — a 4xx just means the probe request itself was rejected (method/auth mismatch), not
+  that the service is down. Excluding a failing provider as a routing candidate up front means an
+  unreachable endpoint fails fast with `Unavailable` instead of being attempted and timing out
+  mid-request. The result is cached (`healthCheckCacheMs`) because the same `capabilities()` call
+  backs both the router (every `run()`) and `checkCapabilities()` (UI introspection) — see
+  `docs/architecture/architecture.md`.
+- **ONNX Apple platform floor.** Shipping `IndeRunOnnxProviders` raised the whole SDK's Apple
+  minimums to iOS 16 / macOS 14, not just for ONNX users — SwiftPM has no per-target platform
+  override in a single manifest, so this was a package-wide, breaking bump. Implementation and
+  known-issue details: [onnx-runtime-provider-family.md](onnx-runtime-provider-family.md).
+- **ONNX Android native dependency.** `local.onnx.genai.android` requires `libc++_shared.so` per
+  ABI; the module gets AGP to package it via a no-op CMake native target because
+  `ai.djl.android:tokenizer-native`'s prebuilt `libdjl_tokenizer.so` links it dynamically without
+  shipping it. Details: [Android Implementation](onnx-runtime-provider-family.md#android-implementation).
+- **Web system-model** — the browser owns model availability/download/execution, unlike the
+  developer-supplied ONNX family. Details: [web-system-model-provider-family.md](web-system-model-provider-family.md).
 - Shared route planning: Rust core used by the TypeScript/Web side and WASM wrapper
   (`@independo/inderun-route-core-wasm`). The Web SDK's default `WasmRoutePlanner`
   (`packages/inderun-web/src/route-planner.ts`) loads it via a static, literal dynamic
@@ -94,6 +87,20 @@ factories), not in prose.
   degrades to the in-process TypeScript fallback planner and reports the reason via the
   `route_decided` telemetry event's `plannerSource`/`plannerUnavailableReason` fields (see
   `docs/architecture/architecture.md`) rather than failing the request or staying silent.
+
+## Provider Authoring Workflow
+
+To add a new provider:
+
+1. Define the static descriptor (`describe`) — provider id, supported task kinds, supported interaction modes (`run` only today; `stream`/`openSession` are descriptor seams, not implementable yet), and declared cancellation behavior (`hard` / `soft` / `none`).
+2. Implement the dynamic capability check (`capabilities(host)`) against the current host — static/OS checks first, then any runtime probe (network reachability, browser feature-detection, etc.), matching the pattern used by the existing providers in the matrix above.
+3. Implement `run()` against the normalized `IndeRunApi` request/response shapes. Do not leak provider-specific request/response fields through the public API.
+4. Map provider-specific failures onto the shared `errorClass` taxonomy (`IndeRunException` / `IndeRunError`, see [Error Model](#error-model)) in the adapter — do not invent a parallel error shape.
+5. Resolve any credentials through `authContextRef`; never place raw secrets in request payloads.
+6. Add tests/fixtures that distinguish "provider unavailable" (capability check fails, route rejected) from "provider available but `run()` failed" (normalized error surfaced).
+7. Update this document: add a row to the [Provider Matrix](#provider-matrix) and, if there's implementation nuance worth recording, a bullet under [Provider Notes](#provider-notes). If the provider needs deeper documentation (e.g. a multi-platform family like ONNX Runtime), add a dedicated `docs/architecture/<family>.md` and link it from here.
+
+See CLAUDE.md §5 for the durable version of the contract expectations above.
 
 ## Current Guidance
 

--- a/docs/architecture/web-system-model-provider-family.md
+++ b/docs/architecture/web-system-model-provider-family.md
@@ -32,14 +32,12 @@ streaming/session support cannot leak in even as unused scaffolding.
 
 ## Browser Support
 
-Desktop Chrome 138+ only (Windows 10/11, macOS 13+, Linux, ChromeOS Chromebook Plus 16389.0.0+),
-requiring roughly 22 GB free storage and either a GPU with >4 GB VRAM or a CPU with 16 GB RAM and
-4+ cores. These figures come from Chrome's own documentation and may drift; consult
-<https://developer.chrome.com/docs/ai/prompt-api> rather than treating them as fixed. Edge exposes
-an analogous API per public announcements, but this family has not verified whether Edge's global
-shares the exact `LanguageModel` surface — do not claim Edge support until confirmed. Firefox and
-Safari are unsupported. Everywhere unsupported, the provider degrades to an honest
-`capability_unavailable` rejection rather than throwing.
+Desktop Chrome 138+ only; Firefox and Safari are unsupported; Edge is unconfirmed. Everywhere
+unsupported, the provider degrades to an honest `capability_unavailable` rejection rather than
+throwing. Exact OS/storage/hardware requirements drift with Chrome's own documentation, so the
+current numbers are consumer-facing content, not architecture — see
+[`packages/inderun-web/README.md`](../../packages/inderun-web/README.md#browser-support) (which
+links to Chrome's own docs) rather than restating them here.
 
 ## Capability State Vocabulary
 
@@ -69,13 +67,12 @@ human-readable text — no new route-rejection codes are added.
 
 ## Provider Error Mapping
 
-| Runtime signal                                        | `errorClass`          |
-| ------------------------------------------------------- | ---------------------- |
-| Any non-`available` capability kind (checked pre-attempt) | `CapabilityMismatch`   |
-| Hardware/browser-feature failure during `generate()`        | `CapabilityMismatch`   |
-| Storage/network constraints, transient failure                | `Unavailable`           |
-| Generation aborted or exceeded its timeout budget                | `Timeout`               |
-| Missing prompt/messages, malformed/empty output, unexpected throwable | `Internal`         |
+Same `errorClass` mapping as documented for consumers in
+[`packages/inderun-web/README.md`](../../packages/inderun-web/README.md#errors) (§ On-Device Models:
+Web System-Model Provider → Errors): capability-gate/hardware failures map to `CapabilityMismatch`,
+storage/network/transient failures to `Unavailable`, aborts/timeouts to `Timeout`, and malformed
+output or unexpected throwables to `Internal`. A purely local runtime never produces `AuthError`,
+`RateLimited`, or `Offline`.
 
 There is no `AuthError`/`RateLimited`/`Offline` path — purely local execution, same as the ONNX
 family and the platform system-model providers.

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxSessionLoading.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/OnnxSessionLoading.swift
@@ -154,6 +154,14 @@ actor LoadedSessionBox {
 
         try verifyChecksums(modelPackage, directory: directory)
 
+        // Loads tokenizer config from an already-resolved local directory with hardcoded literal
+        // filenames only -- no Hub network/download/cache APIs (`HubApi.snapshot(from:)`,
+        // `.from(pretrained:)`, `HubCache`/`HubClient`) are called. Those Hub-network/cache-path
+        // APIs have open CodeQL swift/path-injection findings upstream (`HubCache.cachedFilePath`
+        // builds cache paths from `revision`/`filename` without the same validation
+        // `storeFile`/`storeData` apply; tracked in huggingface/swift-huggingface#62). Before
+        // calling those APIs with a repo ID or filename that isn't a hardcoded literal, check
+        // whether that issue is resolved, and if not, validate repo-id/filename inputs first.
         let tokenizer: Tokenizer
         do {
             tokenizer = try await AutoTokenizer.from(modelFolder: directory)

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime+Decoders.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime+Decoders.swift
@@ -84,6 +84,12 @@ struct FullRecomputeDecoder: StepDecoder {
 /// outputs threaded back in as the next call's `past_key_values.*` inputs directly (no copy),
 /// which is itself the buffer reuse win for this path. The prompt is replayed one token at a time
 /// before real generation begins -- see `step(sampling:)`.
+///
+/// The fixed-at-1 sequence-length shape (as opposed to feeding the whole prompt in one call) was
+/// corrected against a real device failure (`Got invalid dimensions for input: input_ids ...
+/// Expected: 1`) surfaced by a real exported model, LaMini-GPT, in the iOS demo app -- not a
+/// hypothetical constraint. See #88 for remaining real-device verification (load time, memory,
+/// cancellation, other model families).
 struct KvCacheDecoder: StepDecoder {
     let loaded: LoadedSession
     let layout: KvCacheLayout

--- a/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
+++ b/ios/IndeRun/Sources/IndeRunOnnxProviders/SystemOnnxGenAiRuntime.swift
@@ -6,61 +6,18 @@ import Tokenizers
 /// (`microsoft/onnxruntime-swift-package-manager`) for inference and `swift-transformers`'s
 /// `Tokenizers` module for tokenization.
 ///
-/// **IO contract.** This runtime auto-detects, from the loaded graph's declared input names, which
-/// of two decoder-only export shapes a model uses -- no `ModelPackage` field or app-facing
-/// configuration selects it. Both require `input_ids`/`attention_mask` (`int64`) and a `logits`
-/// output (`float32`, `[1, sequenceLength, vocabSize]`):
+/// This type only orchestrates; the actual behavior is documented next to where it's implemented,
+/// not restated here (kept in one place to avoid the two copies drifting apart):
+/// - Decode-strategy auto-detection (plain vs. KV-cache IO contract): `detectDecodeStrategy(session:directory:)`
+///   in `OnnxSessionLoading+KvCacheDetection.swift`.
+/// - Session/execution-provider setup, including the KV-cache/CoreML incompatibility: `OnnxSessionLoading.swift`.
+/// - Sampling (greedy/temperature/top-p): `OnnxSampling.swift`.
+/// - The two decode-step loops: `SystemOnnxGenAiRuntime+Decoders.swift`.
+/// - Chat template application: `encodeInput(_:tokenizer:)` below.
 ///
-/// - **Plain** (no `past_key_values.*` inputs): the full sequence is recomputed on every decode
-///   step. Always supported; the fallback when KV-cache detection can't establish every assumption
-///   below.
-/// - **KV-cache** (`past_key_values.{layer}.key`/`.value` inputs present, matching the legacy
-///   (non-merged) Hugging Face Optimum `decoder_with_past_model` export convention): exactly one
-///   token is fed as `input_ids` per model call -- this graph shape traces `input_ids`'s
-///   sequence-length axis fixed at 1, not dynamic, so it cannot accept the whole prompt in one
-///   call the way a merged/optional-past graph can. The prompt is therefore replayed through the
-///   same session one token at a time (discarding logits) to build up `past_key_values` before the
-///   first real generated token is produced, then generation proceeds one token per call the same
-///   way, with each step's `present.{layer}.key`/`.value` outputs threaded back in as the next
-///   step's `past_key_values.*` inputs. Requires `num_hidden_layers` (or GPT-2-style `n_layer`),
-///   `num_attention_heads`/`n_head` (or `num_key_value_heads`), and `hidden_size`/`n_embd` (or
-///   `head_dim`) to be readable from `config.json` in the model directory; an optional
-///   `position_ids` input is honored if the graph declares it. Graphs that also declare a
-///   `use_cache_branch` boolean input (merged Optimum exports, which accept the whole prompt on
-///   their first call) fall back to the plain path instead -- the ONNX Runtime Objective-C
-///   bindings this runtime depends on expose no `bool` tensor element type to feed it correctly,
-///   and this runtime does not implement the merged graph's alternate calling convention. This
-///   path is designed against the documented Optimum export convention and the ONNX Runtime
-///   Objective-C API; its one-token-per-call shape was corrected against a real device failure
-///   (`Got invalid dimensions for input: input_ids ... Expected: 1`) surfaced by a real exported
-///   model (LaMini-GPT, see the iOS demo app). See #88 for remaining broader real-device
-///   verification (load time, memory, cancellation, other model families).
-///
-/// **Decode loop.** Generation defaults to greedy (argmax); `generation.temperature`/`topP`/`seed`
-/// select sampling (temperature scaling, optional top-p nucleus filtering, seeded when `seed` is
-/// set) instead. `generation.stop` sequences are honored. Session creation and every `run()` call
-/// execute on a dedicated serial queue rather than the Swift Concurrency cooperative pool, since
-/// `ORTSession.run()` is a blocking synchronous call. A single `ORTEnv` is shared process-wide
-/// across sessions, per ORT's own guidance. The CoreML execution provider is configured by default
-/// on the plain decode path, falling back to XNNPACK and then ORT's default CPU EP if CoreML is
-/// unavailable on the host; CoreML compiles the graph into an on-device `.mlmodelc` cache on first
-/// load (managed by ORT/CoreML, not by IndeRun) keyed by the model and execution-provider options,
-/// and invalidated by a changed model file or EP option set. The KV-cache path never uses CoreML,
-/// even when available: its first decode call feeds a genuinely zero-length `past_key_values`
-/// tensor, and ORT's CoreML EP rejects a dynamic-shaped input with zero elements at run time (a
-/// real device failure, not a hypothetical one) -- that graph always runs on XNNPACK/CPU instead.
-/// See `docs/architecture/onnx-runtime-provider-family.md` for the full specification and
-/// residual risks.
-///
-/// **Chat formatting.** Input is tokenized via the tokenizer's chat template
-/// (`Tokenizer.applyChatTemplate`) when the loaded `tokenizer_config.json` declares one, since most
-/// instruction-tuned models require their specific role-tagged special tokens. Tokenizers without a
-/// configured template fall back to a plain `"role: content"` join.
-///
-/// **Model sources.** `bundled` resolves under `Bundle.main.resourceURL`, `filesystem` and
-/// `app_managed` resolve `source.ref` as a directory path (absolute, or relative to the app's
-/// Application Support directory for `app_managed`). `programmatic` has no files to resolve and
-/// is reported as unavailable; apps using `programmatic` sources must supply their own runtime.
+/// Model sources: `bundled` resolves under `Bundle.main.resourceURL`, `filesystem` and
+/// `app_managed` resolve `source.ref` as a directory path. `programmatic` has no files to resolve
+/// and is reported as unavailable; apps using `programmatic` sources must supply their own runtime.
 public final class SystemOnnxGenAiRuntime: OnnxGenAiRuntime {
     private static let defaultMaxOutputTokens = 256
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^11.0.1",
-    "conventional-changelog-conventionalcommits": "^10.2.1",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.9.0",

--- a/packages/inderun-web-demo/README.md
+++ b/packages/inderun-web-demo/README.md
@@ -30,6 +30,22 @@ Multimodal exports (Gemma 4's `any-to-any` E2B/E4B, for example) are split acros
 vision/audio/decoder graphs and do **not** load through that pipeline; they would need a custom
 `OnnxTextGenerationRuntime`.
 
+## Expected Failure Modes
+
+- `CapabilityMismatch`: **On Device** selected but the ONNX Web provider isn't usable in this
+  browser (e.g. no WebGPU/WASM support for the runtime)
+- `Offline`: **Cloud** selected but the browser has no network connection
+- `Unavailable`: the demo proxy or configured cloud endpoint could not be reached, or failed
+  before returning a response
+- `AuthError`: the configured upstream rejected authentication
+- `Internal`: an unexpected runtime or payload-mapping failure occurred
+
+The demo surfaces these as the normalized error shown in place of generated text — see
+[Error Model](../../docs/architecture/providers.md#error-model). Note this demo does not yet
+exercise the Web system-model provider (Chrome Prompt API); see the
+[Provider Matrix](../../docs/architecture/providers.md#provider-matrix) for its dedicated test
+coverage.
+
 ## Security Model
 
 The browser app uses the proxy-first configuration from `@independo/inderun-web`. The browser does not carry raw provider secrets.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1(semantic-release@25.0.9(typescript@6.0.3))
       conventional-changelog-conventionalcommits:
-        specifier: ^10.2.1
-        version: 10.2.1
+        specifier: ^9.3.1
+        version: 9.3.1
       eslint:
         specifier: ^10.8.1
         version: 10.8.1
@@ -154,10 +154,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@conventional-changelog/template@1.2.1':
-    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
-    engines: {node: '>=22'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1296,9 +1292,9 @@ packages:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@7.0.1:
     resolution: {integrity: sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==}
@@ -3319,8 +3315,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@conventional-changelog/template@1.2.1': {}
-
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -4410,9 +4404,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@10.2.1:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      compare-func: 2.0.0
 
   conventional-changelog-writer@7.0.1:
     dependencies:


### PR DESCRIPTION
…EADME with OSS strategy

Three related cleanups on top of Milestone 1/2 provider work:

Stale scope framing (#84/#88 prep)
-----------------------------------
Milestone status now lives in GitHub Issues/Milestones, not this repo; the old Milestone 1/2 scope text in CONTEXT.md (and its README/providers.md mirrors) no longer matched reality -- Milestone 2 provider work had already shipped while the docs still called it future/unimplemented.

#84: Provider Matrix and authoring workflow
--------------------------------------------
Adds a scannable per-family table to providers.md (platform support, task kinds, interaction modes, capability-check behavior, credential/ model loading expectations, limitations) and a step-by-step workflow for adding a new provider, plus a coding-agent requirement to keep the matrix current when provider behavior changes.

#88: Index existing Milestone 2 routing demos/tests ----------------------------------------------------- Milestone 2 provider routing (OpenAI-compat, Apple FM, ML Kit GenAI, ONNX, web system-model) already has coverage scattered across the Rust route-core, TS engine/provider suites, and the iOS/Android sample apps -- adds a single index (per-family demo and test locations, plus how to run each suite) linked from the Provider Matrix, rather than duplicating coverage that already exists. Notes the one real gap honestly: the web demo doesn't yet exercise the web system-model provider, documented in its README's Expected Failure Modes section (mirroring the iOS/Android demos).

Documentation duplication and drift risk
------------------------------------------
The ONNX Runtime provider family docs and code had accumulated the same explanations restated in multiple places -- a standing drift risk, since editing one copy doesn't update the others:

- onnx-runtime-provider-family.md repeated the same explanations across its Web/Apple/Android sections almost verbatim: KV-cache decode-path detection, the CoreML/NNAPI zero-length-tensor rejection, packaging/binary-size boilerplate, and "authoring a custom local provider" guidance (stated 3x). Android/Web now point to the canonical explanation (Apple's, where the behavior was verified against a real device failure) instead of restating it, and "authoring a custom provider" is consolidated into one shared section.
- The same doc had also drifted into documenting implementation internals in prose (exact EP fallback order, buffer allocation strategy, capability gate ordering, error message text) that already existed, near-verbatim, as doc comments at the relevant call sites across all three platforms. Cuts the Web/Apple/Android Implementation sections down to durable, low-drift facts (provider id, runtime seam names, model sources, platform floor) plus a pointer to the source directory that owns the detail.
- One level down, the Apple and Android default runtimes' class-level doc comments restated that same implementation detail in Swift/Kotlin doc comments, duplicating what the implementing functions already document at their own call sites. Trimmed to a short summary plus pointers to the file/function that owns each piece of behavior.
- web-system-model-provider-family.md's Browser Support and Provider Error Mapping sections duplicated packages/inderun-web/README.md almost word for word; the architecture doc now points to the README (the consumer-facing source of truth) instead of carrying its own copy.
- Cleared remaining stale "Milestone 2/3" scope mentions in api-surface-generation.md (left the Options/Recommendation deliberation itself alone -- the doc already flags it as an intentional research record).

Facts that existed in exactly one place and nowhere else were moved, not deleted, to their proper implementing site instead of being lost: the swift-huggingface CVE-tracking note (OnnxSessionLoading.swift), the LaMini-GPT real-device correction behind the Apple KV-cache decode step's one-token-per-call shape (SystemOnnxGenAiRuntime+Decoders.swift), and the Android chat-template permanent-gap note
(SystemAndroidOnnxGenAiRuntime.kt).

Records the underlying rule in CONTEXT.md ("Where technical detail belongs") so future doc edits keep this split: architecture docs carry concepts/contracts/public names, code comments and package READMEs carry the detail that changes with the implementation.

README: align with Independo's OSS communication strategy -------------------------------------------------------------
- Capacitor section no longer links to independo-gmbh/inderun-capacitor (private) or names an unpublished npm package (@independo/capacitor-inderun, confirmed 404 on the registry); it now states factually that the bridge exists and isn't public yet, with no promise on timing.
- Drops the top-of-README Capacitor Actions badge, which pointed at a workflow file that doesn't exist in this repo and 404s.
- Footer now links to Independo's Open Source portfolio page alongside the existing netidee/Independo attribution.

Verified before editing: inderun-capacitor repo is private (visibility: INTERNAL), @independo/capacitor-inderun is unpublished, and the capacitor.yml Actions badge 404s. All other public links (npm packages, Maven Central artifact, netidee, independo.app) resolve correctly.

Also updated GitHub repository metadata: description, homepage (independo.app/open-source), and topics (ai, on-device-ai, edge-ai, cross-platform, sdk, typescript, swift, kotlin, wasm).

No behavior change outside docs and comments.

Closes #84 
Closes #88 