### PR TITLE
fix(ci): discard regenerated WASM stub before semantic-release backmerge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,16 @@ jobs:
       - name: Test workspace (JS)
         run: pnpm test:js
 
+      - name: Discard regenerated WASM bindings stub
+        # packages/inderun-route-core-wasm/generated/inderun_route_core.d.ts is a
+        # hand-written stub checked in on purpose (see its header comment, #109) so
+        # `tsc` can resolve the import without the Rust/wasm-bindgen toolchain. The
+        # "Build Rust WASM bindings" step above intentionally overwrites it with the
+        # real generated bindings for this job's build/test steps. Revert that
+        # overwrite now so the working tree is clean for semantic-release's dev
+        # back-merge (git rebase requires no unstaged changes).
+        run: git checkout -- packages/inderun-route-core-wasm/generated
+
       - name: Semantic Release
         run: npx semantic-release
         env:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -125,6 +125,9 @@ individual, ungrouped PRs and are **not auto-mergeable** — they need manual tr
   requiring the Rust/wasm-bindgen toolchain locally. CI's `wasm-bindgen --target web` step
   overwrites it with the real generated bindings during the build; the stub is not meant to be
   committed back and should only be hand-updated if the Rust route-core API changes.
+  `release.yml` reverts this overwrite (`git checkout -- packages/inderun-route-core-wasm/generated`)
+  right after the workspace build/test steps and before `semantic-release` runs, since
+  semantic-release's dev back-merge does a `git rebase` that fails on any unstaged change.
 - `packages/inderun-web-demo`'s `build` script runs `scripts/verify-wasm-route-planner-bundled.mjs`
   after `vite build`, failing the build if the shared route-core WASM asset and JS chunk are not
   found in `dist/assets/`. This is the regression gate for issue #109: the WASM route planner's


### PR DESCRIPTION
## Summary
- `wasm-bindgen` build step in `release.yml` intentionally overwrites the checked-in `inderun_route_core.d.ts` stub, leaving the working tree dirty
- semantic-release's dev back-merge runs `git rebase origin/main`, which fails on any unstaged change — this broke run [31956657290](https://github.com/independo-gmbh/inderun/actions/runs/31956657290/job/95188208434) (npm publish + GitHub release succeeded, only the dev backmerge failed)
- Add a step to revert the wasm-bindgen overwrite right before `Semantic Release` runs, and document it in `docs/ci.md`

## Test plan
- [x] Reproduced locally: rebuilt the WASM crate + reran `wasm-bindgen` and confirmed it dirties `inderun_route_core.d.ts` against the committed stub
- [x] Validated `release.yml` YAML syntax
- [ ] Watch next `main`/`dev` release run to confirm the backmerge step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)