### PR TITLE
fix(ci): drop broken sdkmanager platform install in maven-publish

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,9 +3,17 @@ name: Maven Publish
 # Publishes the Android library modules to Maven Central when a stable GitHub
 # release is created (by the Release workflow / semantic-release). Prereleases
 # (from the dev branch) are skipped — Maven Central hosts stable releases only.
+# workflow_dispatch allows manually re-running a publish (e.g. against an
+# already-released tag) without cutting a new GitHub release.
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or ref to publish (defaults to the triggering ref)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -13,14 +21,14 @@ permissions:
 jobs:
   maven-publish:
     name: Publish to Maven Central
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Check out the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -32,8 +40,9 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
-      - name: Install Android SDK packages
-        run: sdkmanager "platforms;android-37" "platforms;android-34" "build-tools;34.0.0" "platform-tools"
+      # compileSdk (37) is resolved on demand by Gradle/AGP during the Publish step below,
+      # same as android.yml -- no manual `sdkmanager platforms;...` install needed (and the
+      # android-37 platform package isn't available via sdkmanager's remote repo index yet).
 
       # inderun-onnx-providers declares a CMake native target (see its build.gradle.kts) solely to
       # get AGP to package libc++_shared.so; publishToMavenCentral reaches those tasks, so the


### PR DESCRIPTION
## Summary
- The last two stable releases (`v0.2.0`, `v0.2.1`) failed Maven Publish: the manual `sdkmanager "platforms;android-37" ...` step errors with `Failed to find package 'platforms;android-37'`, since that platform isn't available via sdkmanager's remote repo index yet.
- `android.yml` (the PR/push build+test workflow) never installs platforms manually — Gradle/AGP already resolves `compileSdk 37` on demand during the build, and that workflow is green — so the manual step is redundant as well as broken. Removed it.
- Added `workflow_dispatch` (with an optional `ref` input) so the publish workflow can be re-run manually against an existing tag to verify the fix, without cutting a new GitHub release.
- Note: prereleases (e.g. `v0.2.0-dev.18`) correctly no-op in this workflow by design (`if: !prerelease`, documented in a comment) — that's not a bug, just Maven Central not accepting prereleases.

## Test plan
- [x] Manually triggered via `gh workflow run maven-publish.yml` against this branch: [run 31958474398](https://github.com/independo-gmbh/inderun/actions/runs/31958474398). `Install Android SDK packages` step is gone, `Set up Android SDK` → `Cache/Install Android NDK and CMake` all pass, and the job reaches `./gradlew publishToMavenCentral`, well past the previous failure point. Build then fails as expected with `Component with package url: '...@0.1.2?type=aar' already exists` — that's Maven Central correctly rejecting a re-publish of an already-released version, confirming the original sdkmanager blocker is fixed.
- [ ] Confirm next real stable release publishes successfully end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)