### PR TITLE
fix(deps): override typescript-json-schema to drop vulnerable vm2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   adm-zip@<0.6.0: '>=0.6.0'
   sharp@<0.35.0: '>=0.35.0'
+  typescript-json-schema@<0.68.0: '>=0.68.0'
 
 importers:
 
@@ -3014,8 +3015,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript-json-schema@0.67.4:
-    resolution: {integrity: sha512-BhDCVfwGtPKKt9JOBvh6ocmSbEk7ftx7dpqqIpvGNrjzYcUKm8pnYwKSFfNJwqcp/qNTfZr9sKtVyTxx4V9iRA==}
+  typescript-json-schema@0.68.0:
+    resolution: {integrity: sha512-1X60xXxkZpLAr125Jt5MT9VJTTxT0xfafbjdcbtml26nvpUr2p/P4V34JEXa+ObrHc71W9ksH5pemstY6y+SEw==}
     hasBin: true
 
   typescript@5.9.3:
@@ -3193,11 +3194,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vm2@3.11.5:
-    resolution: {integrity: sha512-RSrkBiwrj6FRU+QdqNs6KG0XdlvJCjpQ4GXiqmMbrhmwfu5k/XIMpAer0L8f6iuf0uJ3a4T1xJN126Q8yf0VIA==}
-    engines: {node: '>=6.0'}
-    hasBin: true
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -5567,7 +5563,7 @@ snapshots:
     dependencies:
       quicktype-core: 26.0.0
       typescript: 5.9.3
-      typescript-json-schema: 0.67.4
+      typescript-json-schema: 0.68.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -6084,7 +6080,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-json-schema@0.67.4:
+  typescript-json-schema@0.68.0:
     dependencies:
       '@types/json-schema': 7.0.15
       '@types/node': 24.13.3
@@ -6093,7 +6089,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       ts-node: 10.9.2(@types/node@24.13.3)(typescript@5.9.3)
       typescript: 5.9.3
-      vm2: 3.11.5
       yargs: 18.1.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -6203,11 +6198,6 @@ snapshots:
       happy-dom: 20.11.2
     transitivePeerDependencies:
       - msw
-
-  vm2@3.11.5:
-    dependencies:
-      acorn: 8.18.0
-      acorn-walk: 8.3.5
 
   web-worker@1.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,11 @@ overrides:
   # GHSA-f88m-g3jw-g9cj: sharp <0.35.0 bundles a libvips with several CVEs.
   # Pulled in transitively via @huggingface/transformers.
   sharp@<0.35.0: ">=0.35.0"
+  # GHSA-m283-3h24-438v, GHSA-m5w8-4gq2-6f8x, GHSA-cfcw-xp6x-25gj: vm2 has
+  # unfixable sandbox-escape RCEs and is deprecated. typescript-json-schema
+  # dropped it entirely in 0.68.0; pulled in transitively via quicktype ->
+  # quicktype-typescript-input, which still pins 0.67.4.
+  typescript-json-schema@<0.68.0: ">=0.68.0"
 allowBuilds:
   esbuild: true
   # Node-only extras pulled in by @huggingface/transformers. The demo runs the ONNX provider in the


### PR DESCRIPTION
## Summary
- `vm2@3.11.5` has 3 critical, unfixable sandbox-escape RCEs (GHSA-m283-3h24-438v, GHSA-m5w8-4gq2-6f8x, GHSA-cfcw-xp6x-25gj) and is deprecated. Pulled in transitively via `quicktype -> quicktype-typescript-input -> typescript-json-schema@0.67.4` — a devDependency used only by `pnpm generate` (contract codegen), never shipped in any published package.
- `typescript-json-schema@0.68.0` dropped `vm2` entirely, but `quicktype-typescript-input@26.0.0` still pins `0.67.4` exactly. Added a `pnpm-workspace.yaml` override forcing `>=0.68.0` until quicktype ships a release that bumps it upstream.

## Test plan
- [x] `pnpm why vm2` — no longer resolves (was 1 hit before)
- [x] `pnpm generate:code` + `pnpm generate:kotlin` (Spotless) — output byte-identical to before the override (only the lockfile/workspace override files changed)
- [x] `pnpm --filter @independo/inderun-contracts build && test` — 44 passed
- [x] `pnpm --filter @independo/inderun-web build` (tsc) + full vitest suite — 130 passed
- [x] `pnpm lint`, `pnpm format:check:js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)