### PR TITLE
ci: install the pinned Rust toolchain explicitly

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,6 +74,12 @@ jobs:
         # the toolchain file decides which compiler actually runs.
         uses: dtolnay/rust-toolchain@stable
 
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
+
       - name: Cache Cargo state
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -79,6 +79,12 @@ jobs:
         # must not be restated here -- see docs/ci.md.
         uses: dtolnay/rust-toolchain@stable
 
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
+
       - name: Cache Cargo state
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -44,6 +44,12 @@ jobs:
         # the toolchain file decides which compiler actually runs.
         uses: dtolnay/rust-toolchain@stable
 
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
+
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,12 @@ jobs:
         # this resolves to.
         uses: dtolnay/rust-toolchain@stable
 
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
+
       - name: Verify the committed route core
         run: pnpm verify:route-core-apple
 
@@ -96,6 +102,12 @@ jobs:
         # rust-toolchain.toml decides which compiler actually runs. The version
         # must not be restated here -- see docs/ci.md.
         uses: dtolnay/rust-toolchain@stable
+
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
 
       - name: Cache Cargo state
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,12 @@ jobs:
         # rust-toolchain.toml decides which compiler actually runs. The version
         # must not be restated here -- see docs/ci.md.
         uses: dtolnay/rust-toolchain@stable
+
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,8 +61,6 @@ jobs:
       # step rather than left to rustup.
       - name: Install the pinned Rust toolchain
         run: rustup toolchain install --no-self-update
-        with:
-          components: rustfmt, clippy
 
       - name: Cache Cargo state
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -81,6 +81,12 @@ jobs:
         # the toolchain file decides which compiler actually runs.
         uses: dtolnay/rust-toolchain@stable
 
+      # The action above only provides rustup. No arguments, so the version still
+      # comes only from rust-toolchain.toml -- see docs/ci.md for why this is a
+      # step rather than left to rustup.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --no-self-update
+
       - name: Cache Cargo state
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -197,9 +197,18 @@ individual, ungrouped PRs and are **not auto-mergeable** — they need manual tr
     build machine has.
 - The Rust toolchain is pinned in `rust-toolchain.toml` rather than tracking `stable`, because
   the XCFramework is a committed executable and "whatever stable was that day" is not something
-  a reviewer can check an artifact against. rustup installs it on demand, so the workflows use
-  the toolchain action only to provide rustup and must not restate the version — a second copy
-  could disagree with the compiler that actually built the artifact.
+  a reviewer can check an artifact against. The workflows use the toolchain action only to
+  provide rustup and must not restate the version — a second copy could disagree with the
+  compiler that actually built the artifact. Every job that needs the pin then runs
+  `rustup toolchain install --no-self-update`, with no toolchain argument so the version still
+  comes from the file alone. That step is required, not belt-and-braces: rustup installs the
+  toolchain a `rust-toolchain.toml` selects, but *not* one named explicitly on the command
+  line, and `scripts/rust-toolchain.mjs` names it explicitly (`rustup run <pin>`,
+  `rustup which --toolchain <pin>`) precisely so a Homebrew rustc on PATH cannot shadow it.
+  Jobs that happen to run cargo from the repo root first — anything with a `Cache Cargo state`
+  step — got the install as a side effect of the toolchain file, which is why the missing step
+  surfaced only in `release.yml`'s macOS verify job, the one job that calls a pinned-toolchain
+  script before any cargo invocation.
 - `packages/inderun-route-core-wasm/generated/` is intentionally not checked in, with one
   exception: `inderun_route_core.d.ts` is a hand-written stub tracked in git so `tsc` can
   resolve the package's literal `import("../generated/inderun_route_core.js")` without

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -208,7 +208,10 @@ individual, ungrouped PRs and are **not auto-mergeable** — they need manual tr
   Jobs that happen to run cargo from the repo root first — anything with a `Cache Cargo state`
   step — got the install as a side effect of the toolchain file, which is why the missing step
   surfaced only in `release.yml`'s macOS verify job, the one job that calls a pinned-toolchain
-  script before any cargo invocation.
+  script before any cargo invocation. Note that `rust-toolchain.toml`'s own header still says
+  rustup installs the pin on demand; it is left alone deliberately, because the file is hashed
+  into the XCFramework's provenance manifest and editing even a comment would invalidate the
+  committed artifact and require a rebuild. This section is the accurate one.
 - `packages/inderun-route-core-wasm/generated/` is intentionally not checked in, with one
   exception: `inderun_route_core.d.ts` is a hand-written stub tracked in git so `tsc` can
   resolve the package's literal `import("../generated/inderun_route_core.js")` without

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,8 +6,9 @@
 # built rather than committed, but pinning keeps every platform's planner on one
 # compiler.
 #
-# rustup installs this on demand, so CI needs no second copy of the version and
-# the workflows keep using the toolchain action only to warm the cache.
+# CI installs this with a bare `rustup toolchain install`, which reads this file,
+# so no workflow needs a second copy of the version -- the toolchain action there
+# only provides rustup itself. Components and targets below come along with it.
 # Bumping it is a deliberate change: rebuild the XCFramework in the same commit.
 [toolchain]
 channel = "1.96.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,9 +6,8 @@
 # built rather than committed, but pinning keeps every platform's planner on one
 # compiler.
 #
-# CI installs this with a bare `rustup toolchain install`, which reads this file,
-# so no workflow needs a second copy of the version -- the toolchain action there
-# only provides rustup itself. Components and targets below come along with it.
+# rustup installs this on demand, so CI needs no second copy of the version and
+# the workflows keep using the toolchain action only to warm the cache.
 # Bumping it is a deliberate change: rebuild the XCFramework in the same commit.
 [toolchain]
 channel = "1.96.0"


### PR DESCRIPTION
The release run for the #164/#171/#172 merge failed in `verify-apple-artifact`:

```
Could not resolve rustc for toolchain '1.96.0'.
Install it with 'rustup toolchain install 1.96.0'.
```

## Cause

rustup installs the toolchain a `rust-toolchain.toml` selects, but **not** one named explicitly on the command line. `scripts/rust-toolchain.mjs` names it explicitly on purpose — `rustup run <pin>`, `rustup which --toolchain <pin>` — so a Homebrew rustc first on PATH cannot shadow the compiler that builds a shipped artifact.

Every other job survived by accident: `Cache Cargo state` runs cargo from the repo root, which installs the pinned toolchain as a side effect of the toolchain file before any script asks for it by name. `verify-apple-artifact` is the only job that calls a pinned-toolchain script with no cargo invocation ahead of it — and `release.yml` only runs on pushes to `main`/`dev`, so no PR could have caught it. The identical `swift.yml` step passed on the very same commit.

## Fix

`rustup toolchain install --no-self-update` in all seven jobs that use the pin, so none depends on step order. No toolchain argument — the version still comes from `rust-toolchain.toml` alone, which is the rule the rest of the setup follows.

`docs/ci.md` claimed rustup installs the pin on demand; that assumption is what left the step out, so it is corrected in the same change.

## Verification

The bare install resolves the pin from the toolchain file with no version restated:

```
$ rustup toolchain install --no-self-update
info: the active toolchain `1.96.0-aarch64-apple-darwin` has been installed
info: it's active because: overridden by '.../rust-toolchain.toml'
```

The real check is this PR's own CI plus the release run after merge, since the failing job is unreachable from a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jy43ekX3icyfF98cbDPtfP