### PR TITLE
docs: put BREAKING CHANGE last in commit messages

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,12 @@
+# <type>(<scope>)<!>: <subject>            # feat|fix|chore|docs|refactor|test|build|ci|perf|style
+#
+# Why the change is needed, and what it does. Wrap at 80.
+#
+# ---- footers -------------------------------------------------------------
+# Normally: issue refs (Closes #123 / Refs #123), then trailers last
+# (Co-Authored-By, Claude-Session, Signed-off-by).
+#
+# When the commit has a BREAKING CHANGE footer, that footer goes LAST and the
+# trailers move above it -- semantic-release reads everything following
+# `BREAKING CHANGE:` as part of the note and publishes it verbatim in the
+# release notes and CHANGELOG. See docs/release.md.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,6 +173,11 @@ Checked-in release commands:
   (prerelease). Config: `.releaserc`; workflow: `.github/workflows/release.yml`. See
   `docs/release.md`. Do not bump versions by hand — semantic-release derives them from
   Conventional Commits and fans the version out via `scripts/set-version.mjs`.
+- When a commit carries a `BREAKING CHANGE:` footer, that footer goes **last** and the
+  trailers (`Co-Authored-By`, `Claude-Session`) move above it — everything after
+  `BREAKING CHANGE:` is parsed as part of the note and published verbatim in the release
+  notes. Commits without one keep trailers last as usual. `.gitmessage` is the template;
+  see `docs/release.md`.
 
 The Rust toolchain is pinned in `rust-toolchain.toml`; rustup honors it automatically. Do not
 restate the version in scripts or workflows — the Apple XCFramework is a committed executable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,15 @@ resolve a JDK 21 installation.
 
 - Use the checked-in commands below rather than inventing new workflow steps.
 - Keep any new tooling documented in this file and `AGENTS.md`.
+- Opt into the commit-message template, which encodes the Conventional Commits footer
+  order this repository's release automation depends on (`BREAKING CHANGE:` last):
+
+  ```sh
+  git config commit.template .gitmessage
+  ```
+
+  Git stores `commit.template` per clone, so this is a one-time step and cannot be
+  checked in for you. See [docs/release.md](docs/release.md) for why the order matters.
 
 ## Commands
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -64,6 +64,32 @@ under its own heading — only the version arithmetic differs. Cutting 1.0.0 is 
 deliberate act: flip `{ breaking: true, release: "minor" }` back to `"major"` in
 `release.config.js` as part of that release.
 
+### Footer order in a commit message
+
+`BREAKING CHANGE:` must be the **last** footer, with nothing after it. Trailers
+(`Co-Authored-By`, `Claude-Session`, `Signed-off-by`) and issue references
+(`Closes #123`) go above it.
+
+semantic-release's parser reads everything after `BREAKING CHANGE:` as part of that
+note and prints it verbatim under the release's ⚠ heading. It does not stop at the
+next trailer, so a trailer placed below the footer is published as if it were part
+of the breaking-change description — `v0.3.0-dev.9`'s iOS entry carries two of them
+for exactly that reason, while the two sibling commits that put the footer last came
+out clean.
+
+`.gitmessage` at the repository root is a template encoding this order. It is not
+active by default, since git keeps `commit.template` in local config:
+
+```sh
+git config commit.template .gitmessage
+```
+
+One trade to know about: GitHub only attributes a `Co-authored-by` trailer when it
+sits in the message's final paragraph, so on a breaking commit the co-author is
+recorded in the message but not shown as a commit author in the GitHub UI. That is
+why the reordering is scoped to breaking commits only — they are the rare case, and
+on them readable release notes are worth more than the avatar.
+
 ## Consuming the packages
 
 **npm**


### PR DESCRIPTION
`v0.3.0-dev.9`'s release notes carried `Co-Authored-By` and `Claude-Session` lines **inside** the iOS breaking-change description:

```
* **ios:** RoutePlanning.planRoute is now throwing ...
  semantics rather than the Swift restatement's.

  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
  Claude-Session: https://claude.ai/code/session_...
```

## Cause

semantic-release reads everything following `BREAKING CHANGE:` as part of that note and prints it verbatim — it does not stop at the next trailer. `db9c157` put its trailers below the footer; `c552e64` and `12053a5` put the footer last and came out clean. That contrast is what identifies the cause rather than guessing at it.

## Fix

There was no commit template in the repository to fix — the trailers come from the tooling that writes the messages — so this adds one and documents the rule where it can actually take effect:

- **`.gitmessage`** at the root, encoding the footer order. Opt-in per clone (`git config commit.template .gitmessage`), because git keeps `commit.template` in local config and it cannot be checked in already active.
- **`docs/release.md`** — the rule, the mechanism, and the trade below.
- **`CONTEXT.md`** (the `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` target) so agents composing commits follow it.
- **`CONTRIBUTING.md`** — the one-time opt-in command.

## Scoped to breaking commits on purpose

GitHub only attributes a `Co-authored-by` trailer when it sits in the message's final paragraph. Moving it above `BREAKING CHANGE:` therefore costs the co-author avatar in the commit list. That is worth paying on the rare breaking commit to keep published notes readable, and not worth paying on every other commit — so commits without a breaking-change footer keep trailers last, as they are now.

Docs only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jy43ekX3icyfF98cbDPtfP