### PR TITLE
chore: merge the 0.2.2 release commit back into dev

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,9 +3,17 @@ name: Maven Publish
 # Publishes the Android library modules to Maven Central when a stable GitHub
 # release is created (by the Release workflow / semantic-release). Prereleases
 # (from the dev branch) are skipped — Maven Central hosts stable releases only.
+# workflow_dispatch allows manually re-running a publish (e.g. against an
+# already-released tag) without cutting a new GitHub release.
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or ref to publish (defaults to the triggering ref)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -13,14 +21,14 @@ permissions:
 jobs:
   maven-publish:
     name: Publish to Maven Central
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Check out the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -32,8 +40,9 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
-      - name: Install Android SDK packages
-        run: sdkmanager "platforms;android-37" "platforms;android-34" "build-tools;34.0.0" "platform-tools"
+      # compileSdk (37) is resolved on demand by Gradle/AGP during the Publish step below,
+      # same as android.yml -- no manual `sdkmanager platforms;...` install needed (and the
+      # android-37 platform package isn't available via sdkmanager's remote repo index yet).
 
       # inderun-onnx-providers declares a CMake native target (see its build.gradle.kts) solely to
       # get AGP to package libc++_shared.so; publishToMavenCentral reaches those tasks, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.2.2](https://github.com/independo-gmbh/inderun/compare/v0.2.1...v0.2.2) (2026-08-16)
+
+### Bug Fixes 🛠️
+
+* **ci:** drop broken sdkmanager platform install in maven-publish ([#143](https://github.com/independo-gmbh/inderun/issues/143)) ([#144](https://github.com/independo-gmbh/inderun/issues/144)) ([e46d26e](https://github.com/independo-gmbh/inderun/commit/e46d26e4679a9f964720168b0e946c4ee34136e1))
+
 ## [0.2.1](https://github.com/independo-gmbh/inderun/compare/v0.2.0...v0.2.1) (2026-08-16)
 
 ### Bug Fixes 🛠️

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,4 +5,4 @@ android.nonTransitiveRClass=true
 # Repo-wide version for the published Maven artifacts. Updated on release by
 # scripts/set-version.mjs (driven by semantic-release); keep in sync with the
 # npm package versions.
-inderunVersion=0.2.1
+inderunVersion=0.2.2

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@independo/inderun-contracts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Canonical JSON Schemas, generated TypeScript types, and validators for IndeRun contracts.",
   "license": "MIT",
   "author": {

--- a/packages/inderun-route-core-wasm/package.json
+++ b/packages/inderun-route-core-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@independo/inderun-route-core-wasm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "WASM wrapper package for the IndeRun Rust route-planning core.",
   "license": "MIT",
   "author": {

--- a/packages/inderun-web/package.json
+++ b/packages/inderun-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@independo/inderun-web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript/Web SDK for IndeRun.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Unblocks the v0.3.0 release PR (#202), which is currently `CONFLICTING`.

## Why this exists

`@semantic-release/git` commits the stable version bump on `main` and it is never back-merged, so `main` has carried `chore(release): 0.2.2` alone since August. Harmless until #201 edited `description` and `keywords` in the three published `package.json` files — adjacent to the `version` line that release commit rewrote — which turned a long-standing divergence into four conflicts on `dev → main`.

## Resolutions

**`.github/workflows/maven-publish.yml` — dev's version, outright.** dev is strictly ahead on three counts that `main`'s copy predates:
- it publishes prereleases to Maven Central (the Capacitor bridge consumes these artifacts from Maven and cannot develop against a `-dev.N` line only npm and SwiftPM have),
- it resolves the published version from the tag rather than `gradle.properties`, which is what stops a prerelease tag publishing under the previous stable version,
- it sets up Node and the pinned Rust toolchain that `:inderun-core`'s jniLibs build needs.

Taking main's copy would have silently reverted all three.

**The three `package.json` files** — dev's `description` and `keywords`, main's `version` (`0.2.2`). `scripts/set-version.mjs` rewrites the version at release time either way; taking main's keeps the recorded version honest in the meantime.

`CHANGELOG.md` and `android/gradle.properties` applied cleanly — the rest of the 0.2.2 bump.

## Net effect on dev

```
CHANGELOG.md                                  | 6 ++++++
android/gradle.properties                     | 2 +-
packages/contracts/package.json               | 2 +-
packages/inderun-route-core-wasm/package.json | 2 +-
packages/inderun-web/package.json             | 2 +-
```

Nothing else moves; `maven-publish.yml` is byte-identical to dev's current copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)